### PR TITLE
refactor: update workflow name mapping to use the short identifier instead of the full resource path

### DIFF
--- a/src/workflows/api.ts
+++ b/src/workflows/api.ts
@@ -18,13 +18,13 @@ export const listWorkflows = async (projectId: string, accessToken: string): Pro
   console.log(body);
 
   return body.workflows?.map((workflow) => {
-    // projects/{project}/locations/{region}/workflows/{workflowId}
     const parts = workflow.name.split("/");
     const region = parts[parts.length - 3];
+    const shortName = parts[parts.length - 1];
 
     return createWorkflow({
       projectId,
-      name: workflow.name,
+      name: shortName,
       region,
       description: workflow.description,
     });


### PR DESCRIPTION
Resolve #10