### PR TITLE
Fix OAuth token state sync after authorization

### DIFF
--- a/src/auth/api.ts
+++ b/src/auth/api.ts
@@ -1,16 +1,36 @@
-export const fetchGoogleApi = async <T>(url: string, accessToken: string): Promise<T> => {
-  const response = await fetch(url, {
+import { refreshGoogleAccessToken } from "./google";
+
+const requestGoogleApi = (url: string, accessToken: string) =>
+  fetch(url, {
     headers: { Authorization: `Bearer ${accessToken}` },
   });
 
-  if (!response.ok) {
-    let errorDetail = "";
-    try {
-      const body = await response.json();
-      errorDetail = JSON.stringify(body);
-    } catch {
-      errorDetail = response.statusText;
+const getErrorDetail = async (response: Response) => {
+  try {
+    const body = await response.json();
+    return JSON.stringify(body);
+  } catch {
+    return response.statusText;
+  }
+};
+
+export const fetchGoogleApi = async <T>(url: string, accessToken: string): Promise<T> => {
+  const response = await requestGoogleApi(url, accessToken);
+
+  if (response.status === 401) {
+    const refreshedAccessToken = await refreshGoogleAccessToken();
+
+    if (refreshedAccessToken) {
+      const retriedResponse = await requestGoogleApi(url, refreshedAccessToken);
+
+      if (retriedResponse.ok) {
+        return (await retriedResponse.json()) as T;
+      }
     }
+  }
+
+  if (!response.ok) {
+    const errorDetail = await getErrorDetail(response);
 
     if (response.status === 401) {
       throw new Error(`Unauthorized (401): Access token is invalid or expired. URL: ${url} Response: ${errorDetail}`);

--- a/src/auth/google.tsx
+++ b/src/auth/google.tsx
@@ -1,4 +1,4 @@
-import { withAccessToken, OAuthService } from "@raycast/utils";
+import { getAccessToken, OAuthService, withAccessToken } from "@raycast/utils";
 
 const OAUTH_CLIENT_ID = "943687027492-ljl37fkhv85e5h6uuevj16dvq4n721ga.apps.googleusercontent.com";
 
@@ -7,35 +7,20 @@ type AuthorizedGoogleApiClient = {
   accessToken: string;
 };
 
-type UnauthorizedGoogleApiClient = {
-  authorized: false;
-};
-
-type GoogleApiClient = AuthorizedGoogleApiClient | UnauthorizedGoogleApiClient;
-
-let googleApi: GoogleApiClient = {
-  authorized: false,
-};
-
 const google = OAuthService.google({
   clientId: OAUTH_CLIENT_ID,
   authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
   tokenUrl: "https://oauth2.googleapis.com/token",
   scope: ["https://www.googleapis.com/auth/cloud-platform"].join(" "),
-  onAuthorize: ({ token }) => {
-    googleApi = {
-      authorized: true,
-      accessToken: token,
-    };
-  },
 });
 
 export const withGoogleAccessToken = withAccessToken(google);
 
 export const useGoogleApi = (): AuthorizedGoogleApiClient => {
-  if (!googleApi.authorized) {
-    throw new Error("Google API is not authorized yet");
-  }
+  const { token } = getAccessToken();
 
-  return googleApi;
+  return {
+    authorized: true,
+    accessToken: token,
+  };
 };

--- a/src/auth/google.tsx
+++ b/src/auth/google.tsx
@@ -1,3 +1,4 @@
+import type { OAuth } from "@raycast/api";
 import { getAccessToken, OAuthService, withAccessToken } from "@raycast/utils";
 
 const OAUTH_CLIENT_ID = "943687027492-ljl37fkhv85e5h6uuevj16dvq4n721ga.apps.googleusercontent.com";
@@ -7,7 +8,7 @@ type AuthorizedGoogleApiClient = {
   accessToken: string;
 };
 
-const google = OAuthService.google({
+export const google = OAuthService.google({
   clientId: OAUTH_CLIENT_ID,
   authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
   tokenUrl: "https://oauth2.googleapis.com/token",
@@ -15,6 +16,30 @@ const google = OAuthService.google({
 });
 
 export const withGoogleAccessToken = withAccessToken(google);
+
+type RefreshableOAuthService = OAuthService & {
+  refreshTokens(args: { token: string }): Promise<OAuth.TokenResponse | undefined>;
+};
+
+export const refreshGoogleAccessToken = async (): Promise<string | undefined> => {
+  const tokens = await google.client.getTokens();
+  const refreshToken = tokens?.refreshToken;
+
+  if (!refreshToken) {
+    return undefined;
+  }
+
+  const refreshedTokens = await (google as RefreshableOAuthService).refreshTokens({ token: refreshToken });
+  const accessToken = refreshedTokens?.access_token;
+
+  if (!accessToken) {
+    return undefined;
+  }
+
+  await google.client.setTokens(refreshedTokens);
+
+  return accessToken;
+};
 
 export const useGoogleApi = (): AuthorizedGoogleApiClient => {
   const { token } = getAccessToken();


### PR DESCRIPTION
## Summary
- remove the extension-managed OAuth token cache in `src/auth/google.tsx`
- read the access token directly from Raycast's `withAccessToken` state via `getAccessToken()`
- fix the post-OAuth failure described in #21 by keeping the command token source in sync

Closes #21
