### PR TITLE
Support Cloud Run detail

### DIFF
--- a/src/cloud-run/CloudRunServicesList.tsx
+++ b/src/cloud-run/CloudRunServicesList.tsx
@@ -27,6 +27,21 @@ export const CloudRunServicesList = (props: Props) => {
             actions={
               <ActionPanel>
                 <Action.OpenInBrowser url={deployment.url} />
+                {deployment.uri && <Action.CopyToClipboard title="Copy Primary URL" content={deployment.uri} />}
+                {(deployment.deployType === "Container Services" || deployment.deployType === "Function Services") && (
+                  <Action.OpenInBrowser
+                    title="Open Revisions in Browser"
+                    url={`https://console.cloud.google.com/run/detail/${deployment.region}/${deployment.name}/revisions?project=${props.projectId}`}
+                    icon={Icon.ChevronRight}
+                  />
+                )}
+                {deployment.deployType === "Jobs" && (
+                  <Action.OpenInBrowser
+                    title="Open Executions in Browser"
+                    url={`https://console.cloud.google.com/run/jobs/details/${deployment.region}/${deployment.name}/executions?project=${props.projectId}`}
+                    icon={Icon.ChevronRight}
+                  />
+                )}
               </ActionPanel>
             }
           />

--- a/src/cloud-run/api.ts
+++ b/src/cloud-run/api.ts
@@ -7,6 +7,7 @@ type CloudRunServicesResponse = {
     description: string;
     uid: string;
     generation: string;
+    uri?: string;
     // Only exists when the service is deployes as Cloud Functions
     buildConfig?: {
       functionTarget: string;
@@ -61,6 +62,7 @@ export const listCloudRunServices = async (projectId: string, accessToken: strin
         region,
         deployType: service.buildConfig === undefined ? "Container Services" : "Function Services",
         url: `https://console.cloud.google.com/run/detail/${region}/${name}?project=${projectId}`,
+        uri: service.uri,
       });
     }) ?? []
   );

--- a/src/cloud-run/types.ts
+++ b/src/cloud-run/types.ts
@@ -4,6 +4,7 @@ export type CloudRunDeployment = {
   region: string;
   deployType: CloudRunDeployType;
   url: string;
+  uri?: string;
   keywords: string[];
 };
 
@@ -15,6 +16,7 @@ export const createCloudRunDeployment = (args: {
   region: string;
   deployType: CloudRunDeployType;
   url: string;
+  uri?: string;
 }): CloudRunDeployment => {
   return {
     id: args.id,
@@ -22,6 +24,7 @@ export const createCloudRunDeployment = (args: {
     region: args.region,
     deployType: args.deployType,
     url: args.url,
+    uri: args.uri,
     keywords: [args.name, args.region, args.deployType],
   };
 };


### PR DESCRIPTION
Closes #45.

This PR adds more detailed actions for Cloud Run services and jobs to improve the UX without adding complex multi-level navigation.

### Changes:
- **For Services:**
  - Added an action to copy the primary URL (`uri`).
  - Added an action to open the Revisions tab directly in the Google Cloud Console.
- **For Jobs:**
  - Added an action to open the Executions tab directly in the Google Cloud Console.
- **API:**
  - Updated the Cloud Run v2 API integration to fetch and map the `uri` field for services.