### PR TITLE
feat(iam): support IAM search

### DIFF
--- a/src/auth/api.ts
+++ b/src/auth/api.ts
@@ -1,6 +1,7 @@
-export const fetchGoogleApi = async <T>(url: string, accessToken: string): Promise<T> => {
+export const fetchGoogleApi = async <T>(url: string, accessToken: string, init?: RequestInit): Promise<T> => {
   const response = await fetch(url, {
-    headers: { Authorization: `Bearer ${accessToken}` },
+    ...init,
+    headers: { Authorization: `Bearer ${accessToken}`, ...init?.headers },
   });
 
   if (!response.ok) {

--- a/src/iam/IamList.tsx
+++ b/src/iam/IamList.tsx
@@ -1,0 +1,36 @@
+import { Action, ActionPanel, Icon, List } from "@raycast/api";
+import { useIamPolicies } from "./useIamPolicies";
+import { ErrorDetail } from "../components/ErrorDetail";
+
+type Props = {
+  projectId: string;
+};
+
+export const IamList = (props: Props) => {
+  const { iamMemberRoles, isLoading, error } = useIamPolicies(props.projectId);
+
+  if (error) {
+    return <ErrorDetail error={error} />;
+  }
+
+  return (
+    <List isLoading={isLoading} searchBarPlaceholder="Search members or roles...">
+      {iamMemberRoles?.map((item) => (
+        <List.Item
+          key={item.id}
+          id={item.id}
+          icon={Icon.Person}
+          title={item.member}
+          subtitle={item.role}
+          actions={
+            <ActionPanel>
+              <Action.OpenInBrowser url={item.url} />
+              <Action.CopyToClipboard title="Copy Member" content={item.member} />
+              <Action.CopyToClipboard title="Copy Role" content={item.role} />
+            </ActionPanel>
+          }
+        />
+      ))}
+    </List>
+  );
+};

--- a/src/iam/IamList.tsx
+++ b/src/iam/IamList.tsx
@@ -20,13 +20,14 @@ export const IamList = (props: Props) => {
           key={item.id}
           id={item.id}
           icon={Icon.Person}
-          title={item.member}
+          title={item.name}
           subtitle={item.role}
+          accessories={[{ text: item.type }]}
           actions={
             <ActionPanel>
-              <Action.OpenInBrowser url={item.url} />
               <Action.CopyToClipboard title="Copy Member" content={item.member} />
               <Action.CopyToClipboard title="Copy Role" content={item.role} />
+              <Action.OpenInBrowser title="Open in Google Cloud Console" url={item.url} />
             </ActionPanel>
           }
         />

--- a/src/iam/api.ts
+++ b/src/iam/api.ts
@@ -1,0 +1,29 @@
+import { fetchGoogleApi } from "../auth/api";
+import { IamMemberRole, IamPolicy } from "./types";
+
+export const fetchIamPolicies = async (projectId: string, accessToken: string): Promise<IamMemberRole[]> => {
+  const data = await fetchGoogleApi<IamPolicy>(
+    `https://cloudresourcemanager.googleapis.com/v1/projects/${projectId}:getIamPolicy`,
+    accessToken,
+    {
+      method: "POST",
+      body: JSON.stringify({}),
+    },
+  );
+
+  const iamMemberRoles: IamMemberRole[] = [];
+  const url = `https://console.cloud.google.com/iam-admin/iam?project=${projectId}`;
+
+  data.bindings?.forEach((binding) => {
+    binding.members.forEach((member) => {
+      iamMemberRoles.push({
+        id: `${member}-${binding.role}`,
+        member,
+        role: binding.role,
+        url,
+      });
+    });
+  });
+
+  return iamMemberRoles;
+};

--- a/src/iam/api.ts
+++ b/src/iam/api.ts
@@ -16,9 +16,12 @@ export const fetchIamPolicies = async (projectId: string, accessToken: string): 
 
   data.bindings?.forEach((binding) => {
     binding.members.forEach((member) => {
+      const { name, type } = parseMember(member);
       iamMemberRoles.push({
         id: `${member}-${binding.role}`,
         member,
+        name,
+        type,
         role: binding.role,
         url,
       });
@@ -26,4 +29,34 @@ export const fetchIamPolicies = async (projectId: string, accessToken: string): 
   });
 
   return iamMemberRoles;
+};
+
+const parseMember = (member: string) => {
+  const [type, ...rest] = member.split(":");
+  const name = rest.join(":");
+
+  switch (type) {
+    case "user":
+      return { type: "User", name };
+    case "serviceAccount":
+      return { type: "Service Account", name };
+    case "group":
+      return { type: "Group", name };
+    case "domain":
+      return { type: "Domain", name };
+    case "projectOwner":
+      return { type: "Project Owner", name: "Project Owner" };
+    case "projectEditor":
+      return { type: "Project Editor", name: "Project Editor" };
+    case "projectViewer":
+      return { type: "Project Viewer", name: "Project Viewer" };
+    case "allUsers":
+      return { type: "All Users", name: "All Users" };
+    case "allAuthenticatedUsers":
+      return { type: "All Auth Users", name: "All Authenticated Users" };
+    case "deleted":
+      return { type: "Deleted", name };
+    default:
+      return { type: "Other", name: member };
+  }
 };

--- a/src/iam/types.ts
+++ b/src/iam/types.ts
@@ -1,0 +1,17 @@
+export type IamBinding = {
+  role: string;
+  members: string[];
+};
+
+export type IamPolicy = {
+  version?: number;
+  bindings?: IamBinding[];
+  etag?: string;
+};
+
+export type IamMemberRole = {
+  id: string;
+  member: string;
+  role: string;
+  url: string;
+};

--- a/src/iam/types.ts
+++ b/src/iam/types.ts
@@ -12,6 +12,8 @@ export type IamPolicy = {
 export type IamMemberRole = {
   id: string;
   member: string;
+  name: string;
+  type: string;
   role: string;
   url: string;
 };

--- a/src/iam/useIamPolicies.ts
+++ b/src/iam/useIamPolicies.ts
@@ -1,0 +1,10 @@
+import { usePromise } from "@raycast/utils";
+import { useGoogleApi } from "../auth/google";
+import { fetchIamPolicies } from "./api";
+
+export const useIamPolicies = (projectId: string) => {
+  const { accessToken } = useGoogleApi();
+  const { data, isLoading, error } = usePromise(fetchIamPolicies, [projectId, accessToken]);
+
+  return { iamMemberRoles: data, isLoading, error };
+};

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -28,6 +28,7 @@ export const searchEnabledServiceNames = [
   "Error Reporting",
   "App Engine",
   "Cloud Build",
+  "IAM & Admin",
 ] as const;
 
 export const searchDisabledServiceNames = [
@@ -47,7 +48,6 @@ export const searchDisabledServiceNames = [
   "Cloud NAT",
   "Cloud DNS",
   "Network Intelligence Center",
-  "IAM & Admin",
   "Workload Identity Federation",
   "Organization Policies",
   "Cloud KMS",

--- a/src/service/useServiceResource.tsx
+++ b/src/service/useServiceResource.tsx
@@ -17,6 +17,7 @@ import { ErrorReportingErrorList } from "../error-reporting/ErrorReportingErrorL
 import { AppEngineServiceList } from "../app-engine/AppEngineServiceList";
 import { CloudBuildList } from "../cloud-build/CloudBuildList";
 import { CloudFunctionList } from "../cloud-functions/CloudFunctionList";
+import { IamList } from "../iam/IamList";
 
 export type UserServiceResourceResult = {
   services: (SearchableService | NonSearchableService)[];
@@ -158,6 +159,13 @@ export const useServiceResource = (projectId: string): UserServiceResourceResult
               keywords,
               isSearchEnabled: true,
               searchAction: <Action.Push title={title} target={<CloudBuildList projectId={projectId} />} />,
+            };
+          case "IAM & Admin":
+            return {
+              ...service,
+              keywords,
+              isSearchEnabled: true,
+              searchAction: <Action.Push title={title} target={<IamList projectId={projectId} />} />,
             };
           default:
             service satisfies never;


### PR DESCRIPTION
This PR implements the IAM search feature (Issue #46).

### Changes
- Updated `fetchGoogleApi` to support `POST` requests, which is required for `getIamPolicy`.
- Added `src/iam/` module to handle fetching and displaying project-level IAM policies.
- Policies are flattened into `(Member, Role)` pairs to provide a clean and searchable list in Raycast.
- Enabled searching for "IAM & Admin" in the service resource list.

### Verification
- `npm run lint`: Passed
- `npm run type-check`: Passed
- `npm run build`: Passed

closes #46