### PR TITLE
feat: support pagination for Secret Manager

### DIFF
--- a/src/secret-manager/api.ts
+++ b/src/secret-manager/api.ts
@@ -3,6 +3,7 @@ import { SecretManagerSecret } from "./types";
 
 type SecretManagerSecretsResponse = {
   secrets?: { name: string }[];
+  nextPageToken?: string;
 };
 
 /**
@@ -11,23 +12,41 @@ type SecretManagerSecretsResponse = {
 export const listSecretManagerSecrets = async (
   projectId: string,
   accessToken: string,
+  onPageFetched?: (secrets: SecretManagerSecret[]) => void,
 ): Promise<SecretManagerSecret[]> => {
-  const body = await fetchGoogleApi<SecretManagerSecretsResponse>(
-    `https://secretmanager.googleapis.com/v1beta1/projects/${projectId}/secrets`,
-    accessToken,
-  );
-  const secrets =
-    body.secrets?.map((secret) => {
-      // projects/{project}/secrets/{secretId}
-      const parts = secret.name.split("/");
-      const name = parts[parts.length - 1];
+  const allSecrets: SecretManagerSecret[] = [];
+  let pageToken: string | undefined;
 
-      return {
-        id: secret.name,
-        name: name,
-        url: `https://console.cloud.google.com/security/secret-manager/secret/${name}?project=${projectId}`,
-      };
-    }) ?? [];
+  do {
+    const query = new URLSearchParams();
+    if (pageToken) {
+      query.set("pageToken", pageToken);
+    }
 
-  return secrets;
+    const suffix = query.toString();
+    const body = await fetchGoogleApi<SecretManagerSecretsResponse>(
+      `https://secretmanager.googleapis.com/v1beta1/projects/${projectId}/secrets${suffix ? `?${suffix}` : ""}`,
+      accessToken,
+    );
+
+    const secrets =
+      body.secrets?.map((secret) => {
+        // projects/{project}/secrets/{secretId}
+        const parts = secret.name.split("/");
+        const name = parts[parts.length - 1];
+
+        return {
+          id: secret.name,
+          name: name,
+          url: `https://console.cloud.google.com/security/secret-manager/secret/${name}?project=${projectId}`,
+        };
+      }) ?? [];
+
+    allSecrets.push(...secrets);
+    onPageFetched?.(allSecrets);
+
+    pageToken = body.nextPageToken;
+  } while (pageToken);
+
+  return allSecrets;
 };

--- a/src/secret-manager/useSecretManager.ts
+++ b/src/secret-manager/useSecretManager.ts
@@ -1,30 +1,39 @@
+import { useState } from "react";
 import { usePromise } from "@raycast/utils";
 import { useGoogleApi } from "../auth/google";
 import { listSecretManagerSecrets } from "./api";
 import { SecretManagerSecret } from "./types";
 
-type UseSecretManagerResult =
-  | {
-      secrets: SecretManagerSecret[];
-      isLoading: boolean;
-      error: undefined;
-    }
-  | {
-      secrets: undefined;
-      isLoading: true;
-      error: undefined;
-    }
-  | {
-      secrets: undefined;
-      isLoading: false;
-      error: Error;
-    };
+type SuccessResult = {
+  secrets: SecretManagerSecret[];
+  isLoading: boolean;
+  error: undefined;
+};
+
+type LoadingResult = {
+  secrets: undefined;
+  isLoading: true;
+  error: undefined;
+};
+
+type ErrorResult = {
+  secrets: undefined;
+  isLoading: false;
+  error: Error;
+};
+
+type UseSecretManagerResult = SuccessResult | LoadingResult | ErrorResult;
 
 export const useSecretManager = (projectId: string): UseSecretManagerResult => {
   const { accessToken } = useGoogleApi();
-  const { data, isLoading, error } = usePromise(
+  const [progressiveSecrets, setProgressiveSecrets] = useState<SecretManagerSecret[]>([]);
+
+  const { isLoading, error } = usePromise(
     async (projId: string, token: string) => {
-      return await listSecretManagerSecrets(projId, token);
+      setProgressiveSecrets([]);
+      return await listSecretManagerSecrets(projId, token, (secrets) => {
+        setProgressiveSecrets([...secrets]);
+      });
     },
     [projectId, accessToken],
   );
@@ -33,9 +42,9 @@ export const useSecretManager = (projectId: string): UseSecretManagerResult => {
     return { secrets: undefined, isLoading: false, error };
   }
 
-  if (!data) {
+  if (isLoading && progressiveSecrets.length === 0) {
     return { secrets: undefined, isLoading: true, error: undefined };
   }
 
-  return { secrets: data, isLoading, error: undefined };
+  return { secrets: progressiveSecrets, isLoading, error: undefined };
 };


### PR DESCRIPTION
This PR implements pagination support for Secret Manager with progressive rendering.

### Changes
- **API**: Updated `listSecretManagerSecrets` to support pagination via a do-while loop and an `onPageFetched` callback.
- **Hook**: Updated `useSecretManager` to support progressive rendering using the new API callback.
- **Refactor**: Standardized hook result types with named aliases (`SuccessResult`, `LoadingResult`, `ErrorResult`).

### Why progressive rendering?
Raycast uses client-side incremental search. Standard infinite scroll would prevent items in un-loaded pages from being searchable. This approach fetches all pages eagerly while rendering them as they arrive, ensuring all items are searchable as soon as possible.

closes #49