### PR TITLE
ci: prevent dependabot type drift and slack noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 3
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "@types/react"
+      - dependency-name: "@types/node"
     groups:
       npm-dependencies:
         patterns:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm run build
       - uses: ./.github/actions/slack-notify
         if: |
-          always() && (
+          secrets.SLACK_WEBHOOK != '' && always() && (
             (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
             (github.event_name == 'pull_request' && job.status != 'success')
           )

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm run lint
       - uses: ./.github/actions/slack-notify
         if: |
-          always() && (
+          secrets.SLACK_WEBHOOK != '' && always() && (
             (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
             (github.event_name == 'pull_request' && job.status != 'success')
           )

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm run type-check
       - uses: ./.github/actions/slack-notify
         if: |
-          always() && (
+          secrets.SLACK_WEBHOOK != '' && always() && (
             (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
             (github.event_name == 'pull_request' && job.status != 'success')
           )


### PR DESCRIPTION
## Summary
- ignore @types/react and @types/node in Dependabot npm updates to avoid breaking Raycast type compatibility
- skip Slack notification steps when SLACK_WEBHOOK is unavailable
- keep failed PR jobs focused on the primary CI failure instead of a follow-up notification error

## Verification
- npm ci
- npm run lint
- npm run type-check
- npm run build