### PR TITLE
fix(ci): resolve "Invalid workflow file" by removing secrets from if conditionals

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,11 @@ jobs:
         run: npm run build
       - uses: ./.github/actions/slack-notify
         if: |
-          secrets.SLACK_WEBHOOK != '' && always() && (
+          always() && (
             (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
             (github.event_name == 'pull_request' && job.status != 'success')
           )
+        continue-on-error: true
         with:
           status: ${{ job.status }}
           webhook_url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,10 +23,11 @@ jobs:
         run: npm run lint
       - uses: ./.github/actions/slack-notify
         if: |
-          secrets.SLACK_WEBHOOK != '' && always() && (
+          always() && (
             (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
             (github.event_name == 'pull_request' && job.status != 'success')
           )
+        continue-on-error: true
         with:
           status: ${{ job.status }}
           webhook_url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -23,10 +23,11 @@ jobs:
         run: npm run type-check
       - uses: ./.github/actions/slack-notify
         if: |
-          secrets.SLACK_WEBHOOK != '' && always() && (
+          always() && (
             (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
             (github.event_name == 'pull_request' && job.status != 'success')
           )
+        continue-on-error: true
         with:
           status: ${{ job.status }}
           webhook_url: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
GitHub Actions does not allow referencing the `secrets` context directly within `if:` conditionals. This was causing validation errors and preventing CI from running on all branches/PRs.

This PR:
- Removes the `secrets.SLACK_WEBHOOK` check from the `if:` condition.
- Adds `continue-on-error: true` to the Slack notification step to gracefully handle cases where the webhook is not configured (e.g., Dependabot PRs or forks) without exposing the secret as a job-level environment variable.

Closes #56 (indirectly) and restores CI functionality.