### PR TITLE
Support progressive pagination for Cloud Run resources

### DIFF
--- a/src/cloud-run/api.ts
+++ b/src/cloud-run/api.ts
@@ -12,6 +12,7 @@ type CloudRunServicesResponse = {
       functionTarget: string;
     };
   }[];
+  nextPageToken?: string;
 };
 
 type CloudRunJobsResponse = {
@@ -25,6 +26,9 @@ type CloudRunJobsResponse = {
       };
     };
   }[];
+  metadata: {
+    continue?: string;
+  };
 };
 
 type CloudRunWorkerPoolsResponse = {
@@ -38,80 +42,143 @@ type CloudRunWorkerPoolsResponse = {
       };
     };
   }[];
+  metadata: {
+    continue?: string;
+  };
 };
 
 /**
  * @see https://docs.cloud.google.com/run/docs/reference/rest/v2/projects.locations.services/list
  */
-export const listCloudRunServices = async (projectId: string, accessToken: string): Promise<CloudRunDeployment[]> => {
-  const body = await fetchGoogleApi<CloudRunServicesResponse>(
-    `https://run.googleapis.com/v2/projects/${projectId}/locations/-/services`,
-    accessToken,
-  );
+export const listCloudRunServices = async (
+  projectId: string,
+  accessToken: string,
+  onPageFetched?: (services: CloudRunDeployment[]) => void,
+): Promise<CloudRunDeployment[]> => {
+  const allServices: CloudRunDeployment[] = [];
+  let pageToken: string | undefined;
 
-  return (
-    body.services?.map((service) => {
-      const parts = service.name.split("/");
-      const region = parts[parts.length - 3];
-      const name = parts[parts.length - 1];
+  do {
+    const query = new URLSearchParams();
+    if (pageToken) {
+      query.set("pageToken", pageToken);
+    }
 
-      return createCloudRunDeployment({
-        id: service.uid,
-        name,
-        region,
-        deployType: service.buildConfig === undefined ? "Container Services" : "Function Services",
-        url: `https://console.cloud.google.com/run/detail/${region}/${name}?project=${projectId}`,
-      });
-    }) ?? []
-  );
+    const suffix = query.toString();
+    const body = await fetchGoogleApi<CloudRunServicesResponse>(
+      `https://run.googleapis.com/v2/projects/${projectId}/locations/-/services${suffix ? `?${suffix}` : ""}`,
+      accessToken,
+    );
+
+    const services =
+      body.services?.map((service) => {
+        const parts = service.name.split("/");
+        const region = parts[parts.length - 3];
+        const name = parts[parts.length - 1];
+
+        return createCloudRunDeployment({
+          id: service.uid,
+          name,
+          region,
+          deployType: service.buildConfig === undefined ? "Container Services" : "Function Services",
+          url: `https://console.cloud.google.com/run/detail/${region}/${name}?project=${projectId}`,
+        });
+      }) ?? [];
+
+    allServices.push(...services);
+    onPageFetched?.(allServices);
+
+    pageToken = body.nextPageToken;
+  } while (pageToken);
+
+  return allServices;
 };
 
 /**
  * @see https://docs.cloud.google.com/run/docs/reference/rest/v2/projects.locations.jobs/list
  */
-export const listCloudRunJobs = async (projectId: string, accessToken: string): Promise<CloudRunDeployment[]> => {
-  const body = await fetchGoogleApi<CloudRunJobsResponse>(
-    `https://run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${projectId}/jobs`,
-    accessToken,
-  );
+export const listCloudRunJobs = async (
+  projectId: string,
+  accessToken: string,
+  onPageFetched?: (jobs: CloudRunDeployment[]) => void,
+): Promise<CloudRunDeployment[]> => {
+  const allJobs: CloudRunDeployment[] = [];
+  let continueToken: string | undefined;
 
-  return (
-    body.items?.map((job) => {
-      const name = job.metadata.name;
-      const region = job.metadata.labels["cloud.googleapis.com/location"];
+  do {
+    const query = new URLSearchParams();
+    if (continueToken) {
+      query.set("continue", continueToken);
+    }
 
-      return createCloudRunDeployment({
-        id: job.metadata.uid,
-        name,
-        region,
-        deployType: "Jobs" as const,
-        url: `https://console.cloud.google.com/run/jobs/details/${region}/${name}?project=${projectId}`,
-      });
-    }) ?? []
-  );
+    const suffix = query.toString();
+    const body = await fetchGoogleApi<CloudRunJobsResponse>(
+      `https://run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${projectId}/jobs${suffix ? `?${suffix}` : ""}`,
+      accessToken,
+    );
+
+    const jobs =
+      body.items?.map((job) => {
+        const name = job.metadata.name;
+        const region = job.metadata.labels["cloud.googleapis.com/location"];
+
+        return createCloudRunDeployment({
+          id: job.metadata.uid,
+          name,
+          region,
+          deployType: "Jobs" as const,
+          url: `https://console.cloud.google.com/run/jobs/details/${region}/${name}?project=${projectId}`,
+        });
+      }) ?? [];
+
+    allJobs.push(...jobs);
+    onPageFetched?.(allJobs);
+
+    continueToken = body.metadata.continue;
+  } while (continueToken);
+
+  return allJobs;
 };
 
 export const listCloudRunWorkerPools = async (
   projectId: string,
   accessToken: string,
+  onPageFetched?: (workerPools: CloudRunDeployment[]) => void,
 ): Promise<CloudRunDeployment[]> => {
-  const body = await fetchGoogleApi<CloudRunWorkerPoolsResponse>(
-    `https://run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${projectId}/workerpools`,
-    accessToken,
-  );
+  const allWorkerPools: CloudRunDeployment[] = [];
+  let continueToken: string | undefined;
 
-  return (
-    body.items?.map((workerPool) => {
-      const name = workerPool.metadata.name;
-      const region = workerPool.metadata.labels["cloud.googleapis.com/location"];
+  do {
+    const query = new URLSearchParams();
+    if (continueToken) {
+      query.set("continue", continueToken);
+    }
 
-      return createCloudRunDeployment({
-        id: workerPool.metadata.uid,
-        name,
-        region,
-        deployType: "Worker Pools" as const,
-        url: `https://console.cloud.google.com/run/worker-pools/detail/${region}/${name}?project=${projectId}`,
-      });
-    }) ?? []
-  );
+    const suffix = query.toString();
+    const body = await fetchGoogleApi<CloudRunWorkerPoolsResponse>(
+      `https://run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${projectId}/workerpools${suffix ? `?${suffix}` : ""}`,
+      accessToken,
+    );
+
+    const workerPools =
+      body.items?.map((workerPool) => {
+        const name = workerPool.metadata.name;
+        const region = workerPool.metadata.labels["cloud.googleapis.com/location"];
+
+        return createCloudRunDeployment({
+          id: workerPool.metadata.uid,
+          name,
+          region,
+          deployType: "Worker Pools" as const,
+          url: `https://console.cloud.google.com/run/worker-pools/detail/${region}/${name}?project=${projectId}`,
+        });
+      }) ?? [];
+
+    allWorkerPools.push(...workerPools);
+    onPageFetched?.(allWorkerPools);
+
+    continueToken = body.metadata.continue;
+  } while (continueToken);
+
+  return allWorkerPools;
 };

--- a/src/cloud-run/api.ts
+++ b/src/cloud-run/api.ts
@@ -26,7 +26,7 @@ type CloudRunJobsResponse = {
       };
     };
   }[];
-  metadata: {
+  metadata?: {
     continue?: string;
   };
 };
@@ -42,7 +42,7 @@ type CloudRunWorkerPoolsResponse = {
       };
     };
   }[];
-  metadata: {
+  metadata?: {
     continue?: string;
   };
 };
@@ -134,7 +134,7 @@ export const listCloudRunJobs = async (
     allJobs.push(...jobs);
     onPageFetched?.(allJobs);
 
-    continueToken = body.metadata.continue;
+    continueToken = body.metadata?.continue;
   } while (continueToken);
 
   return allJobs;
@@ -177,7 +177,7 @@ export const listCloudRunWorkerPools = async (
     allWorkerPools.push(...workerPools);
     onPageFetched?.(allWorkerPools);
 
-    continueToken = body.metadata.continue;
+    continueToken = body.metadata?.continue;
   } while (continueToken);
 
   return allWorkerPools;

--- a/src/cloud-run/useCloudRunDeployments.ts
+++ b/src/cloud-run/useCloudRunDeployments.ts
@@ -36,9 +36,13 @@ export const useCloudRunDeployments = (projectId: string): UseCloudRunDeployment
 
   const isLoading = isLoadingServices || isLoadingJobs || isLoadingWorkerPools;
 
-  if (isLoading || !services || !jobs || !workerPools) {
+  if (isLoading && !services && !jobs && !workerPools) {
     return { deployments: undefined, isLoading: true, error: undefined };
   }
 
-  return { deployments: [...services, ...jobs, ...workerPools], isLoading: false, error: undefined };
+  return {
+    deployments: [...(services ?? []), ...(jobs ?? []), ...(workerPools ?? [])],
+    isLoading,
+    error: undefined,
+  };
 };

--- a/src/cloud-run/useCloudRunJobs.ts
+++ b/src/cloud-run/useCloudRunJobs.ts
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { usePromise } from "@raycast/utils";
 import { useGoogleApi } from "../auth/google";
 import { listCloudRunJobs } from "./api";
@@ -25,9 +26,14 @@ type UseCloudRunJobsResult = SuccessResult | LoadingResult | ErrorResult;
 
 export const useCloudRunJobs = (projectId: string): UseCloudRunJobsResult => {
   const { accessToken } = useGoogleApi();
-  const { data, isLoading, error } = usePromise(
+  const [progressiveJobs, setProgressiveJobs] = useState<CloudRunDeployment[]>([]);
+
+  const { isLoading, error } = usePromise(
     async (projId: string, token: string) => {
-      return await listCloudRunJobs(projId, token);
+      setProgressiveJobs([]);
+      return await listCloudRunJobs(projId, token, (jobs) => {
+        setProgressiveJobs([...jobs]);
+      });
     },
     [projectId, accessToken],
   );
@@ -36,9 +42,9 @@ export const useCloudRunJobs = (projectId: string): UseCloudRunJobsResult => {
     return { jobs: undefined, isLoading: false, error };
   }
 
-  if (!data) {
+  if (isLoading && progressiveJobs.length === 0) {
     return { jobs: undefined, isLoading: true, error: undefined };
   }
 
-  return { jobs: data, isLoading, error: undefined };
+  return { jobs: progressiveJobs, isLoading, error: undefined };
 };

--- a/src/cloud-run/useCloudRunServices.ts
+++ b/src/cloud-run/useCloudRunServices.ts
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { usePromise } from "@raycast/utils";
 import { useGoogleApi } from "../auth/google";
 import { listCloudRunServices } from "./api";
@@ -25,9 +26,14 @@ type UseCloudRunServicesResult = SuccessResult | LoadingResult | ErrorResult;
 
 export const useCloudRunServices = (projectId: string): UseCloudRunServicesResult => {
   const { accessToken } = useGoogleApi();
-  const { data, isLoading, error } = usePromise(
+  const [progressiveServices, setProgressiveServices] = useState<CloudRunDeployment[]>([]);
+
+  const { isLoading, error } = usePromise(
     async (projId: string, token: string) => {
-      return await listCloudRunServices(projId, token);
+      setProgressiveServices([]);
+      return await listCloudRunServices(projId, token, (services) => {
+        setProgressiveServices([...services]);
+      });
     },
     [projectId, accessToken],
   );
@@ -36,9 +42,9 @@ export const useCloudRunServices = (projectId: string): UseCloudRunServicesResul
     return { services: undefined, isLoading: false, error };
   }
 
-  if (!data) {
+  if (isLoading && progressiveServices.length === 0) {
     return { services: undefined, isLoading: true, error: undefined };
   }
 
-  return { services: data, isLoading, error: undefined };
+  return { services: progressiveServices, isLoading, error: undefined };
 };

--- a/src/cloud-run/useCloudRunWorkerPools.ts
+++ b/src/cloud-run/useCloudRunWorkerPools.ts
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { usePromise } from "@raycast/utils";
 import { useGoogleApi } from "../auth/google";
 import { listCloudRunWorkerPools } from "./api";
@@ -25,9 +26,14 @@ type UseCloudRunWorkerPoolsResult = SuccessResult | LoadingResult | ErrorResult;
 
 export const useCloudRunWorkerPools = (projectId: string): UseCloudRunWorkerPoolsResult => {
   const { accessToken } = useGoogleApi();
-  const { data, isLoading, error } = usePromise(
+  const [progressiveWorkerPools, setProgressiveWorkerPools] = useState<CloudRunDeployment[]>([]);
+
+  const { isLoading, error } = usePromise(
     async (projId: string, token: string) => {
-      return await listCloudRunWorkerPools(projId, token);
+      setProgressiveWorkerPools([]);
+      return await listCloudRunWorkerPools(projId, token, (workerPools) => {
+        setProgressiveWorkerPools([...workerPools]);
+      });
     },
     [projectId, accessToken],
   );
@@ -36,9 +42,9 @@ export const useCloudRunWorkerPools = (projectId: string): UseCloudRunWorkerPool
     return { workerPools: undefined, isLoading: false, error };
   }
 
-  if (!data) {
+  if (isLoading && progressiveWorkerPools.length === 0) {
     return { workerPools: undefined, isLoading: true, error: undefined };
   }
 
-  return { workerPools: data, isLoading, error: undefined };
+  return { workerPools: progressiveWorkerPools, isLoading, error: undefined };
 };


### PR DESCRIPTION
This PR implements progressive pagination for Cloud Run resources (services, jobs, and worker pools) to improve responsiveness when there are many resources. It follows the pattern established for Secret Manager in #49.

### Changes:
- Updated `src/cloud-run/api.ts` to support pagination tokens and progressive updates.
- Refactored Cloud Run hooks to use `useState` for progressive rendering.
- Standardized hook result types to `SuccessResult`, `LoadingResult`, and `ErrorResult`.
- Updated aggregate hook `useCloudRunDeployments` to return partial data while loading.

closes #50