### PR TITLE
feat: add cloud logging shortcuts for Cloud Run and Cloud Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,65 +25,67 @@ This extension provides the following commands:
 
 This extension supports quick navigation to Google Cloud services. For some services, you can also search and navigate directly to their resources (like instances, buckets, or clusters).
 
-| Service Name | Category | Resource Search |
-|---|---|---|
-| AlloyDB | Database | Clusters |
-| BigQuery | Data Analytics | - |
-| BigQuery Data Transfer | Data Analytics | - |
-| Bigtable | Database | - |
-| Cloud SQL | Database | Instances |
-| Cloud Spanner | Database | - |
-| Firestore | Database | - |
-| Datastore | Database | - |
-| Memorystore | Database | - |
-| Compute Engine | Compute | - |
-| Kubernetes Engine | Compute | - |
-| Cloud Run | Compute | Services |
-| Cloud Functions | Compute | Functions (gen1) |
-| App Engine | Compute | Services |
-| Batch | Compute | - |
-| Cloud Storage | Storage | Buckets |
-| Transfer Service | Storage | - |
-| VPC Networks | Networking | - |
-| Load Balancing | Networking | - |
-| Cloud NAT | Networking | - |
-| Cloud DNS | Networking | - |
-| Network Intelligence Center | Networking | - |
-| IAM & Admin | Security | - |
-| Service Accounts | Security | Service Accounts |
-| Workload Identity Federation | Security | - |
-| Organization Policies | Security | - |
-| Secret Manager | Security | Secrets |
-| Cloud KMS | Security | - |
-| Certificate Manager | Security | - |
-| Security Command Center | Security | - |
-| Web Security Scanner | Security | - |
-| Cloud Logging | Operations | - |
-| Cloud Monitoring | Operations | - |
-| Error Reporting | Operations | Errors |
-| Cloud Trace | Operations | - |
-| Cloud Profiler | Operations | - |
-| Cloud Debugger | Operations | - |
-| Pub/Sub | Integration | Topics & Subscriptions |
-| Eventarc | Integration | - |
-| Workflows | Integration | Workflows |
-| Cloud Scheduler | Integration | Jobs |
-| Cloud Tasks | Integration | Queues |
-| Artifact Registry | DevOps | Repositories |
-| Cloud Build | DevOps | Builds |
-| Source Repositories | DevOps | - |
-| Deployment Manager | DevOps | - |
-| Dataproc | Data Analytics | - |
-| Dataflow | Data Analytics | - |
-| Composer | Data Analytics | - |
-| Data Fusion | Data Analytics | - |
-| Dataplex | Data Analytics | - |
-| Vertex AI | Machine Learning | - |
-| Vertex AI Workbench | Machine Learning | - |
-| AutoML | Machine Learning | - |
-| API & Services | Billing | - |
-| API Library | Billing | - |
-| Credentials | Billing | - |
-| Billing | Billing | - |
-| Quotas | Billing | - |
-| Budgets & Alerts | Billing | - |
+Cloud Logging shortcuts are rolled out incrementally. The table below shows the current support status for both resource search and Cloud Logging shortcuts.
+
+| Service Name | Category | Resource Search | Cloud Logging Shortcut |
+|---|---|---|---|
+| AlloyDB | Database | Clusters | - |
+| BigQuery | Data Analytics | - | - |
+| BigQuery Data Transfer | Data Analytics | - | - |
+| Bigtable | Database | - | - |
+| Cloud SQL | Database | Instances | - |
+| Cloud Spanner | Database | - | - |
+| Firestore | Database | - | - |
+| Datastore | Database | - | - |
+| Memorystore | Database | - | - |
+| Compute Engine | Compute | - | - |
+| Kubernetes Engine | Compute | - | - |
+| Cloud Run | Compute | Services | Yes |
+| Cloud Functions | Compute | Functions (gen1) | Yes |
+| App Engine | Compute | Services | - |
+| Batch | Compute | - | - |
+| Cloud Storage | Storage | Buckets | - |
+| Transfer Service | Storage | - | - |
+| VPC Networks | Networking | - | - |
+| Load Balancing | Networking | - | - |
+| Cloud NAT | Networking | - | - |
+| Cloud DNS | Networking | - | - |
+| Network Intelligence Center | Networking | - | - |
+| IAM & Admin | Security | - | - |
+| Service Accounts | Security | Service Accounts | - |
+| Workload Identity Federation | Security | - | - |
+| Organization Policies | Security | - | - |
+| Secret Manager | Security | Secrets | - |
+| Cloud KMS | Security | - | - |
+| Certificate Manager | Security | - | - |
+| Security Command Center | Security | - | - |
+| Web Security Scanner | Security | - | - |
+| Cloud Logging | Operations | - | - |
+| Cloud Monitoring | Operations | - | - |
+| Error Reporting | Operations | Errors | - |
+| Cloud Trace | Operations | - | - |
+| Cloud Profiler | Operations | - | - |
+| Cloud Debugger | Operations | - | - |
+| Pub/Sub | Integration | Topics & Subscriptions | - |
+| Eventarc | Integration | - | - |
+| Workflows | Integration | Workflows | - |
+| Cloud Scheduler | Integration | Jobs | - |
+| Cloud Tasks | Integration | Queues | - |
+| Artifact Registry | DevOps | Repositories | - |
+| Cloud Build | DevOps | Builds | - |
+| Source Repositories | DevOps | - | - |
+| Deployment Manager | DevOps | - | - |
+| Dataproc | Data Analytics | - | - |
+| Dataflow | Data Analytics | - | - |
+| Composer | Data Analytics | - | - |
+| Data Fusion | Data Analytics | - | - |
+| Dataplex | Data Analytics | - | - |
+| Vertex AI | Machine Learning | - | - |
+| Vertex AI Workbench | Machine Learning | - | - |
+| AutoML | Machine Learning | - | - |
+| API & Services | Billing | - | - |
+| API Library | Billing | - | - |
+| Credentials | Billing | - | - |
+| Billing | Billing | - | - |
+| Quotas | Billing | - | - |
+| Budgets & Alerts | Billing | - | - |

--- a/src/actions/cloud-logging/OpenCloudLoggingAction.tsx
+++ b/src/actions/cloud-logging/OpenCloudLoggingAction.tsx
@@ -1,0 +1,11 @@
+import { Action } from "@raycast/api";
+import { createCloudLoggingUrl } from "./createCloudLoggingUrl";
+import { CloudLoggingTarget } from "./types";
+
+type Props = {
+  target: CloudLoggingTarget;
+};
+
+export const OpenCloudLoggingAction = ({ target }: Props) => {
+  return <Action.OpenInBrowser title="Open Logs" url={createCloudLoggingUrl(target)} />;
+};

--- a/src/actions/cloud-logging/createCloudLoggingUrl.ts
+++ b/src/actions/cloud-logging/createCloudLoggingUrl.ts
@@ -1,0 +1,34 @@
+import { CloudLoggingTarget } from "./types";
+
+const createCloudLoggingQuery = (target: CloudLoggingTarget): string => {
+  switch (target.kind) {
+    case "cloud-function-gen1":
+      return [
+        'resource.type="cloud_function"',
+        `resource.labels.function_name="${target.name}"`,
+        `resource.labels.region="${target.region}"`,
+      ].join("\n");
+    case "cloud-run-job":
+      return [
+        'resource.type="cloud_run_job"',
+        `resource.labels.job_name="${target.name}"`,
+        `resource.labels.location="${target.region}"`,
+      ].join("\n");
+    case "cloud-run-service":
+      return [
+        'resource.type="cloud_run_revision"',
+        `resource.labels.service_name="${target.name}"`,
+        `resource.labels.location="${target.region}"`,
+      ].join("\n");
+    case "cloud-run-worker-pool":
+      return [
+        'resource.type="cloud_run_worker_pool"',
+        `resource.labels.worker_pool_name="${target.name}"`,
+        `resource.labels.location="${target.region}"`,
+      ].join("\n");
+  }
+};
+
+export const createCloudLoggingUrl = (target: CloudLoggingTarget): string => {
+  return `https://console.cloud.google.com/logs/query;query=${encodeURIComponent(createCloudLoggingQuery(target))}?project=${encodeURIComponent(target.projectId)}`;
+};

--- a/src/actions/cloud-logging/createCloudLoggingUrl.ts
+++ b/src/actions/cloud-logging/createCloudLoggingUrl.ts
@@ -1,31 +1,40 @@
 import { CloudLoggingTarget } from "./types";
 
+type CloudLoggingFilter = {
+  key: string;
+  value: string;
+};
+
+const createCloudLoggingQueryFromFilters = (filters: CloudLoggingFilter[]): string => {
+  return filters.map(({ key, value }) => `${key}=${JSON.stringify(value)}`).join("\n");
+};
+
 const createCloudLoggingQuery = (target: CloudLoggingTarget): string => {
   switch (target.kind) {
     case "cloud-function-gen1":
-      return [
-        'resource.type="cloud_function"',
-        `resource.labels.function_name="${target.name}"`,
-        `resource.labels.region="${target.region}"`,
-      ].join("\n");
+      return createCloudLoggingQueryFromFilters([
+        { key: "resource.type", value: "cloud_function" },
+        { key: "resource.labels.function_name", value: target.name },
+        { key: "resource.labels.region", value: target.region },
+      ]);
     case "cloud-run-job":
-      return [
-        'resource.type="cloud_run_job"',
-        `resource.labels.job_name="${target.name}"`,
-        `resource.labels.location="${target.region}"`,
-      ].join("\n");
+      return createCloudLoggingQueryFromFilters([
+        { key: "resource.type", value: "cloud_run_job" },
+        { key: "resource.labels.job_name", value: target.name },
+        { key: "resource.labels.location", value: target.region },
+      ]);
     case "cloud-run-service":
-      return [
-        'resource.type="cloud_run_revision"',
-        `resource.labels.service_name="${target.name}"`,
-        `resource.labels.location="${target.region}"`,
-      ].join("\n");
+      return createCloudLoggingQueryFromFilters([
+        { key: "resource.type", value: "cloud_run_revision" },
+        { key: "resource.labels.service_name", value: target.name },
+        { key: "resource.labels.location", value: target.region },
+      ]);
     case "cloud-run-worker-pool":
-      return [
-        'resource.type="cloud_run_worker_pool"',
-        `resource.labels.worker_pool_name="${target.name}"`,
-        `resource.labels.location="${target.region}"`,
-      ].join("\n");
+      return createCloudLoggingQueryFromFilters([
+        { key: "resource.type", value: "cloud_run_worker_pool" },
+        { key: "resource.labels.worker_pool_name", value: target.name },
+        { key: "resource.labels.location", value: target.region },
+      ]);
   }
 };
 

--- a/src/actions/cloud-logging/types.ts
+++ b/src/actions/cloud-logging/types.ts
@@ -1,0 +1,25 @@
+export type CloudLoggingTarget =
+  | {
+      kind: "cloud-function-gen1";
+      projectId: string;
+      name: string;
+      region: string;
+    }
+  | {
+      kind: "cloud-run-job";
+      projectId: string;
+      name: string;
+      region: string;
+    }
+  | {
+      kind: "cloud-run-service";
+      projectId: string;
+      name: string;
+      region: string;
+    }
+  | {
+      kind: "cloud-run-worker-pool";
+      projectId: string;
+      name: string;
+      region: string;
+    };

--- a/src/cloud-functions/CloudFunctionList.tsx
+++ b/src/cloud-functions/CloudFunctionList.tsx
@@ -1,4 +1,5 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
+import { OpenCloudLoggingAction } from "../actions/cloud-logging/OpenCloudLoggingAction";
 import { ErrorDetail } from "../components/ErrorDetail";
 import { useCloudFunctions } from "./useCloudFunctions";
 
@@ -29,6 +30,7 @@ export const CloudFunctionList = ({ projectId }: Props) => {
           ].filter((a) => a.text)}
           actions={
             <ActionPanel>
+              <OpenCloudLoggingAction target={cloudFunction} />
               <Action.OpenInBrowser url={cloudFunction.url} />
             </ActionPanel>
           }

--- a/src/cloud-functions/types.ts
+++ b/src/cloud-functions/types.ts
@@ -1,12 +1,12 @@
+import { CloudLoggingTarget } from "../actions/cloud-logging/types";
+
 export type CloudFunction = {
   id: string;
-  name: string;
-  region: string;
   status?: string;
   runtime?: string;
   url: string;
   keywords: string[];
-};
+} & Extract<CloudLoggingTarget, { kind: "cloud-function-gen1" }>;
 
 export const createCloudFunction = (args: {
   projectId: string;
@@ -18,6 +18,8 @@ export const createCloudFunction = (args: {
 }): CloudFunction => {
   return {
     id: args.id,
+    kind: "cloud-function-gen1",
+    projectId: args.projectId,
     name: args.name,
     region: args.region,
     status: args.status,

--- a/src/cloud-run/CloudRunServicesList.tsx
+++ b/src/cloud-run/CloudRunServicesList.tsx
@@ -1,4 +1,5 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
+import { OpenCloudLoggingAction } from "../actions/cloud-logging/OpenCloudLoggingAction";
 import { useCloudRunDeployments } from "./useCloudRunDeployments";
 import { ErrorDetail } from "../components/ErrorDetail";
 
@@ -26,6 +27,7 @@ export const CloudRunServicesList = (props: Props) => {
             accessories={[{ text: deployment.deployType }, { text: deployment.region }]}
             actions={
               <ActionPanel>
+                <OpenCloudLoggingAction target={deployment} />
                 <Action.OpenInBrowser url={deployment.url} />
               </ActionPanel>
             }

--- a/src/cloud-run/api.ts
+++ b/src/cloud-run/api.ts
@@ -78,6 +78,7 @@ export const listCloudRunServices = async (
 
         return createCloudRunDeployment({
           id: service.uid,
+          projectId,
           name,
           region,
           deployType: service.buildConfig === undefined ? "Container Services" : "Function Services",
@@ -124,6 +125,7 @@ export const listCloudRunJobs = async (
 
         return createCloudRunDeployment({
           id: job.metadata.uid,
+          projectId,
           name,
           region,
           deployType: "Jobs" as const,
@@ -167,6 +169,7 @@ export const listCloudRunWorkerPools = async (
 
         return createCloudRunDeployment({
           id: workerPool.metadata.uid,
+          projectId,
           name,
           region,
           deployType: "Worker Pools" as const,

--- a/src/cloud-run/types.ts
+++ b/src/cloud-run/types.ts
@@ -1,11 +1,11 @@
+import { CloudLoggingTarget } from "../actions/cloud-logging/types";
+
 export type CloudRunDeployment = {
   id: string;
-  name: string;
-  region: string;
   deployType: CloudRunDeployType;
   url: string;
   keywords: string[];
-};
+} & Extract<CloudLoggingTarget, { kind: "cloud-run-job" | "cloud-run-service" | "cloud-run-worker-pool" }>;
 
 export type CloudRunDeployType = "Function Services" | "Container Services" | "Jobs" | "Worker Pools";
 
@@ -14,10 +14,20 @@ export const createCloudRunDeployment = (args: {
   name: string;
   region: string;
   deployType: CloudRunDeployType;
+  projectId: string;
   url: string;
 }): CloudRunDeployment => {
+  const kind =
+    args.deployType === "Jobs"
+      ? "cloud-run-job"
+      : args.deployType === "Worker Pools"
+        ? "cloud-run-worker-pool"
+        : "cloud-run-service";
+
   return {
     id: args.id,
+    kind,
+    projectId: args.projectId,
     name: args.name,
     region: args.region,
     deployType: args.deployType,

--- a/src/cloud-run/types.ts
+++ b/src/cloud-run/types.ts
@@ -9,6 +9,16 @@ export type CloudRunDeployment = {
 
 export type CloudRunDeployType = "Function Services" | "Container Services" | "Jobs" | "Worker Pools";
 
+const cloudRunLoggingKindByDeployType: Record<
+  CloudRunDeployType,
+  Extract<CloudLoggingTarget, { kind: "cloud-run-job" | "cloud-run-service" | "cloud-run-worker-pool" }>["kind"]
+> = {
+  "Function Services": "cloud-run-service",
+  "Container Services": "cloud-run-service",
+  Jobs: "cloud-run-job",
+  "Worker Pools": "cloud-run-worker-pool",
+};
+
 export const createCloudRunDeployment = (args: {
   id: string;
   name: string;
@@ -17,16 +27,9 @@ export const createCloudRunDeployment = (args: {
   projectId: string;
   url: string;
 }): CloudRunDeployment => {
-  const kind =
-    args.deployType === "Jobs"
-      ? "cloud-run-job"
-      : args.deployType === "Worker Pools"
-        ? "cloud-run-worker-pool"
-        : "cloud-run-service";
-
   return {
     id: args.id,
-    kind,
+    kind: cloudRunLoggingKindByDeployType[args.deployType],
     projectId: args.projectId,
     name: args.name,
     region: args.region,


### PR DESCRIPTION
## Summary
- add a reusable `actions/cloud-logging` layer for opening Logs Explorer with a prefilled query
- add Cloud Logging shortcuts to Cloud Run resources and Cloud Functions list items
- map Cloud Run deployment types to resource-granularity logging kinds

## Testing
- npm run lint
- npm run type-check
- npm run build

Closes #60.
