### PR TITLE
chore(ci): skip CI for markdown and assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**/*.md"
+      - "assets/**"
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "assets/**"
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**/*.md"
+      - "assets/**"
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "assets/**"
 
 jobs:
   lint:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**/*.md"
+      - "assets/**"
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "assets/**"
 
 jobs:
   typecheck:


### PR DESCRIPTION
## Description
Updates the GitHub Action workflows to use `paths-ignore` so that CI is skipped when only markdown files (`**/*.md`) or assets (`assets/**`) are changed. This helps reduce excessive CI runs while ensuring CI doesn't miss newly added directories or files.