### PR TITLE
fix: Standardize the log shortcut

### DIFF
--- a/src/actions/cloud-logging/OpenCloudLoggingAction.tsx
+++ b/src/actions/cloud-logging/OpenCloudLoggingAction.tsx
@@ -7,5 +7,11 @@ type Props = {
 };
 
 export const OpenCloudLoggingAction = ({ target }: Props) => {
-  return <Action.OpenInBrowser title="Open Logs" url={createCloudLoggingUrl(target)} />;
+  return (
+    <Action.OpenInBrowser
+      title="Open Logs"
+      url={createCloudLoggingUrl(target)}
+      shortcut={{ modifiers: ["cmd"], key: "l" }}
+    />
+  );
 };

--- a/src/cloud-functions/CloudFunctionList.tsx
+++ b/src/cloud-functions/CloudFunctionList.tsx
@@ -30,8 +30,8 @@ export const CloudFunctionList = ({ projectId }: Props) => {
           ].filter((a) => a.text)}
           actions={
             <ActionPanel>
-              <OpenCloudLoggingAction target={cloudFunction} />
               <Action.OpenInBrowser url={cloudFunction.url} />
+              <OpenCloudLoggingAction target={cloudFunction} />
             </ActionPanel>
           }
         />

--- a/src/cloud-run/CloudRunServicesList.tsx
+++ b/src/cloud-run/CloudRunServicesList.tsx
@@ -27,8 +27,8 @@ export const CloudRunServicesList = (props: Props) => {
             accessories={[{ text: deployment.deployType }, { text: deployment.region }]}
             actions={
               <ActionPanel>
-                <OpenCloudLoggingAction target={deployment} />
                 <Action.OpenInBrowser url={deployment.url} />
+                <OpenCloudLoggingAction target={deployment} />
                 {deployment.uri && <Action.CopyToClipboard title="Copy Primary URL" content={deployment.uri} />}
                 {(deployment.deployType === "Container Services" || deployment.deployType === "Function Services") && (
                   <Action.OpenInBrowser

--- a/src/error-reporting/ErrorReportingErrorList.tsx
+++ b/src/error-reporting/ErrorReportingErrorList.tsx
@@ -54,12 +54,12 @@ export const ErrorReportingErrorList = ({ projectId }: Props) => {
             detail={<ErrorGroupDetail group={group} />}
             actions={
               <ActionPanel>
+                <Action.OpenInBrowser url={group.url} />
                 <Action
                   title={showDetail ? "Hide Detail" : "Show Detail"}
                   icon={showDetail ? Icon.EyeDisabled : Icon.Eye}
                   onAction={() => setShowDetail(!showDetail)}
                 />
-                <Action.OpenInBrowser url={group.url} />
                 <Action.CopyToClipboard title="Copy Error Message" content={group.representative.message} />
               </ActionPanel>
             }


### PR DESCRIPTION
closes #77

## Description
This PR standardizes the "Cloud Logging" shortcut and the default behavior of the Enter key across the extension.

- Assigns `Cmd + L` to `OpenCloudLoggingAction`.
- Moves the `<Action.OpenInBrowser />` (for opening the Cloud Console) to be the first item in the `<ActionPanel>` for Cloud Functions, Cloud Run, and Error Reporting lists, ensuring that the **Enter key** always opens the console by default.

## Verification
- Verified via `npm run lint`, `npm run type-check`, and `npm run build` locally.
