### PR TITLE
Bound Cloud Storage bucket pagination

### DIFF
--- a/src/cloud-storage/CloudStorageBucketList.tsx
+++ b/src/cloud-storage/CloudStorageBucketList.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useCloudStorage } from "./useCloudStorage";
 import { ErrorDetail } from "../components/ErrorDetail";
@@ -7,14 +8,37 @@ type Props = {
 };
 
 export const CloudStorageBucketList = (props: Props) => {
-  const { buckets, isLoading, error } = useCloudStorage(props.projectId);
+  const [searchText, setSearchText] = useState("");
+  const { buckets, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } = useCloudStorage(props.projectId);
 
   if (error) {
     return <ErrorDetail error={error} />;
   }
 
+  const canLoadMore = hasMore && !isTruncated;
+  const loadMoreAction = canLoadMore ? (
+    <Action title="Load More Buckets" icon={Icon.ArrowDown} onAction={loadMore} />
+  ) : undefined;
+
   return (
-    <List isLoading={isLoading}>
+    <List
+      isLoading={isLoading || isLoadingMore}
+      filtering
+      onSearchTextChange={setSearchText}
+      searchBarPlaceholder="Search loaded buckets..."
+    >
+      <List.EmptyView
+        icon={Icon.MagnifyingGlass}
+        title={searchText && canLoadMore ? "No loaded buckets match this search" : "No buckets found"}
+        description={
+          searchText && canLoadMore
+            ? "More buckets may exist. Load more buckets to expand the searchable set."
+            : isTruncated
+              ? "The bucket list is truncated to keep memory usage bounded."
+              : undefined
+        }
+        actions={loadMoreAction ? <ActionPanel>{loadMoreAction}</ActionPanel> : undefined}
+      />
       {buckets?.map((bucket) => (
         <List.Item
           key={bucket.id}
@@ -25,10 +49,28 @@ export const CloudStorageBucketList = (props: Props) => {
           actions={
             <ActionPanel>
               <Action.OpenInBrowser url={bucket.url} />
+              {loadMoreAction}
             </ActionPanel>
           }
         />
       ))}
+      {canLoadMore && (
+        <List.Item
+          id="load-more-cloud-storage-buckets"
+          title="Load More Buckets"
+          icon={Icon.ArrowDown}
+          accessories={[{ text: `${buckets?.length ?? 0} loaded` }]}
+          actions={<ActionPanel>{loadMoreAction}</ActionPanel>}
+        />
+      )}
+      {isTruncated && (
+        <List.Item
+          id="cloud-storage-buckets-truncated"
+          title="Bucket List Truncated"
+          icon={Icon.ExclamationMark}
+          accessories={[{ text: `${buckets?.length ?? 0} loaded` }]}
+        />
+      )}
     </List>
   );
 };

--- a/src/cloud-storage/api.ts
+++ b/src/cloud-storage/api.ts
@@ -7,25 +7,43 @@ type CloudStorageBucketResponse = {
     name: string;
     location: string;
   }[];
+  nextPageToken?: string;
+};
+
+export type CloudStorageBucketPage = {
+  buckets: CloudStorageBucket[];
+  nextPageToken?: string;
 };
 
 /**
  * @see https://docs.cloud.google.com/storage/docs/json_api/v1/buckets/list
  */
-export const listCloudStorageBuckets = async (
+export const listCloudStorageBucketsPage = async (
   projectId: string,
   accessToken: string,
-): Promise<CloudStorageBucket[]> => {
+  options: { pageSize: number; pageToken?: string },
+): Promise<CloudStorageBucketPage> => {
+  const query = new URLSearchParams({
+    project: projectId,
+    maxResults: options.pageSize.toString(),
+  });
+  if (options.pageToken) {
+    query.set("pageToken", options.pageToken);
+  }
+
   const body = await fetchGoogleApi<CloudStorageBucketResponse>(
-    `https://www.googleapis.com/storage/v1/b?project=${projectId}`,
+    `https://www.googleapis.com/storage/v1/b?${query.toString()}`,
     accessToken,
   );
-  return (
-    body.items?.map((item) => ({
-      id: item.id,
-      name: item.name,
-      location: item.location,
-      url: `https://console.cloud.google.com/storage/browser/${item.name}?project=${projectId}`,
-    })) ?? []
-  );
+
+  return {
+    buckets:
+      body.items?.map((item) => ({
+        id: item.id,
+        name: item.name,
+        location: item.location,
+        url: `https://console.cloud.google.com/storage/browser/${item.name}?project=${projectId}`,
+      })) ?? [],
+    nextPageToken: body.nextPageToken,
+  };
 };

--- a/src/cloud-storage/useCloudStorage.ts
+++ b/src/cloud-storage/useCloudStorage.ts
@@ -1,23 +1,39 @@
+import { useCallback, useState } from "react";
 import { usePromise } from "@raycast/utils";
 import { useGoogleApi } from "../auth/google";
-import { listCloudStorageBuckets } from "./api";
+import { listCloudStorageBucketsPage } from "./api";
 import { CloudStorageBucket } from "./types";
+
+const CLOUD_STORAGE_BUCKET_PAGE_SIZE = 50;
+const CLOUD_STORAGE_BUCKET_LIMIT = 500;
 
 type SuccessResult = {
   buckets: CloudStorageBucket[];
   isLoading: boolean;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  isTruncated: boolean;
+  loadMore: () => Promise<void>;
   error: undefined;
 };
 
 type LoadingResult = {
   buckets: undefined;
   isLoading: true;
+  isLoadingMore: false;
+  hasMore: false;
+  isTruncated: false;
+  loadMore: () => Promise<void>;
   error: undefined;
 };
 
 type ErrorResult = {
   buckets: undefined;
   isLoading: false;
+  isLoadingMore: false;
+  hasMore: false;
+  isTruncated: false;
+  loadMore: () => Promise<void>;
   error: Error;
 };
 
@@ -25,20 +41,94 @@ type UseCloudStorageResult = SuccessResult | LoadingResult | ErrorResult;
 
 export const useCloudStorage = (projectId: string): UseCloudStorageResult => {
   const { accessToken } = useGoogleApi();
-  const { data, isLoading, error } = usePromise(
+  const [buckets, setBuckets] = useState<CloudStorageBucket[]>([]);
+  const [nextPageToken, setNextPageToken] = useState<string | undefined>();
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isTruncated, setIsTruncated] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState<Error | undefined>();
+
+  const loadMore = useCallback(async () => {
+    if (!nextPageToken || isLoadingMore || isTruncated) {
+      return;
+    }
+
+    setIsLoadingMore(true);
+    setLoadMoreError(undefined);
+    try {
+      const page = await listCloudStorageBucketsPage(projectId, accessToken, {
+        pageSize: CLOUD_STORAGE_BUCKET_PAGE_SIZE,
+        pageToken: nextPageToken,
+      });
+
+      const nextBuckets = [...buckets, ...page.buckets];
+      if (nextBuckets.length >= CLOUD_STORAGE_BUCKET_LIMIT) {
+        setBuckets(nextBuckets.slice(0, CLOUD_STORAGE_BUCKET_LIMIT));
+        setNextPageToken(undefined);
+        setIsTruncated(Boolean(page.nextPageToken) || nextBuckets.length > CLOUD_STORAGE_BUCKET_LIMIT);
+      } else {
+        setBuckets(nextBuckets);
+        setNextPageToken(page.nextPageToken);
+      }
+    } catch (error) {
+      setLoadMoreError(error instanceof Error ? error : new Error(String(error)));
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [accessToken, buckets, isLoadingMore, isTruncated, nextPageToken, projectId]);
+
+  const noopLoadMore = useCallback(async () => undefined, []);
+
+  const { isLoading, error } = usePromise(
     async (projId: string, token: string) => {
-      return await listCloudStorageBuckets(projId, token);
+      setBuckets([]);
+      setNextPageToken(undefined);
+      setIsTruncated(false);
+      setLoadMoreError(undefined);
+
+      const page = await listCloudStorageBucketsPage(projId, token, {
+        pageSize: CLOUD_STORAGE_BUCKET_PAGE_SIZE,
+      });
+
+      setBuckets(page.buckets.slice(0, CLOUD_STORAGE_BUCKET_LIMIT));
+      setNextPageToken(page.buckets.length >= CLOUD_STORAGE_BUCKET_LIMIT ? undefined : page.nextPageToken);
+      setIsTruncated(page.buckets.length >= CLOUD_STORAGE_BUCKET_LIMIT && Boolean(page.nextPageToken));
     },
     [projectId, accessToken],
   );
 
-  if (error) {
-    return { buckets: undefined, isLoading: false, error };
+  const resultError = error || loadMoreError;
+
+  if (resultError) {
+    return {
+      buckets: undefined,
+      isLoading: false,
+      isLoadingMore: false,
+      hasMore: false,
+      isTruncated: false,
+      loadMore: noopLoadMore,
+      error: resultError,
+    };
   }
 
-  if (!data) {
-    return { buckets: undefined, isLoading: true, error: undefined };
+  if (isLoading && buckets.length === 0) {
+    return {
+      buckets: undefined,
+      isLoading: true,
+      isLoadingMore: false,
+      hasMore: false,
+      isTruncated: false,
+      loadMore: noopLoadMore,
+      error: undefined,
+    };
   }
 
-  return { buckets: data, isLoading, error: undefined };
+  return {
+    buckets,
+    isLoading,
+    isLoadingMore,
+    hasMore: Boolean(nextPageToken),
+    isTruncated,
+    loadMore,
+    error: undefined,
+  };
 };


### PR DESCRIPTION
## Summary

- Add page-based Cloud Storage bucket fetching with `maxResults` and `pageToken`
- Load only the first bucket page initially, then expose an explicit `Load More Buckets` action
- Add a 500 bucket retention cap and UI messaging for partial/truncated results
- Keep search scoped to loaded buckets and explain when more buckets may exist

refs #79

## Verification

- `npm run type-check`
- `npm run lint`
- `npm run build`

## Notes

This PR applies the bounded pagination approach to Cloud Storage first. Cloud Run and Secret Manager still use their existing pagination behavior and can be handled separately after this approach is reviewed.
