### PR TITLE
feat(service): display ArrowNe icon when resource search is unsupported

### DIFF
--- a/src/service/ServiceList.tsx
+++ b/src/service/ServiceList.tsx
@@ -7,7 +7,6 @@ type Props = {
 
 export const ServiceList = (props: Props) => {
   const { services } = useServiceResource(props.projectId);
-  const searchAccessory = [{ icon: Icon.MagnifyingGlass, tooltip: "Show Resources" }];
 
   return (
     <List>
@@ -17,7 +16,12 @@ export const ServiceList = (props: Props) => {
           title={service.name}
           keywords={service.keywords}
           icon={Icon.ComputerChip}
-          accessories={[{ text: service.category }, ...(service.isSearchEnabled ? searchAccessory : [])]}
+          accessories={[
+            { text: service.category },
+            service.isSearchEnabled
+              ? { icon: Icon.MagnifyingGlass, tooltip: "Show Resources" }
+              : { icon: Icon.ArrowNe, tooltip: "Open in Browser" },
+          ].filter((a) => a.text || a.icon)}
           actions={
             <ActionPanel>
               {service.isSearchEnabled && service.searchAction}


### PR DESCRIPTION
## Description

This PR changes the icon displayed in the service list for Google Cloud resources where search is not supported.
Instead of showing the `MagnifyingGlass` icon, we now display the `ArrowNe` (Arrow North-East) icon with the tooltip `"Open in Browser"`, indicating that the action will open the corresponding page in the Google Cloud Console directly rather than opening an in-extension resource list.

## Changes
- Updated `ServiceList.tsx` to conditionally render `Icon.ArrowNe` with `"Open in Browser"` tooltip when `isSearchEnabled` is false.
- Filtered the accessories array to prevent empty elements from appearing, satisfying the project guidelines in `AGENTS.md`.

## Verification
Ran local checks to verify code integrity:
- `npm run lint` -> Passed
- `npm run type-check` -> Passed
- `npm run build` -> Passed