### PR TITLE
feat: bound Secret Manager pagination

### DIFF
--- a/src/secret-manager/SecretManagerList.tsx
+++ b/src/secret-manager/SecretManagerList.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useSecretManager } from "./useSecretManager";
 import { ErrorDetail } from "../components/ErrorDetail";
@@ -7,14 +8,39 @@ type Props = {
 };
 
 export const SecretManagerList = (props: Props) => {
-  const { secrets, isLoading, error } = useSecretManager(props.projectId);
+  const [searchText, setSearchText] = useState("");
+  const { secrets, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } = useSecretManager(
+    props.projectId,
+  );
 
   if (error) {
     return <ErrorDetail error={error} />;
   }
 
+  const canLoadMore = hasMore && !isTruncated;
+  const loadMoreAction = canLoadMore ? (
+    <Action title="Load More Secrets" icon={Icon.ArrowDown} onAction={loadMore} />
+  ) : undefined;
+
   return (
-    <List isLoading={isLoading}>
+    <List
+      isLoading={isLoading || isLoadingMore}
+      filtering
+      onSearchTextChange={setSearchText}
+      searchBarPlaceholder="Search loaded secrets..."
+    >
+      <List.EmptyView
+        icon={Icon.MagnifyingGlass}
+        title={searchText && canLoadMore ? "No loaded secrets match this search" : "No secrets found"}
+        description={
+          searchText && canLoadMore
+            ? "More secrets may exist. Load more secrets to expand the searchable set."
+            : isTruncated
+              ? "The secret list is truncated to keep memory usage bounded."
+              : undefined
+        }
+        actions={loadMoreAction ? <ActionPanel>{loadMoreAction}</ActionPanel> : undefined}
+      />
       {secrets?.map((secret) => (
         <List.Item
           key={secret.id}
@@ -24,10 +50,28 @@ export const SecretManagerList = (props: Props) => {
           actions={
             <ActionPanel>
               <Action.OpenInBrowser url={secret.url} />
+              {loadMoreAction}
             </ActionPanel>
           }
         />
       ))}
+      {canLoadMore && (
+        <List.Item
+          id="load-more-secrets"
+          title="Load More Secrets"
+          icon={Icon.ArrowDown}
+          accessories={[{ text: `${secrets?.length ?? 0} loaded` }]}
+          actions={<ActionPanel>{loadMoreAction}</ActionPanel>}
+        />
+      )}
+      {isTruncated && (
+        <List.Item
+          id="secret-manager-secrets-truncated"
+          title="Secret List Truncated"
+          icon={Icon.ExclamationMark}
+          accessories={[{ text: `${secrets?.length ?? 0} loaded` }]}
+        />
+      )}
     </List>
   );
 };

--- a/src/secret-manager/api.ts
+++ b/src/secret-manager/api.ts
@@ -6,47 +6,46 @@ type SecretManagerSecretsResponse = {
   nextPageToken?: string;
 };
 
+export type SecretManagerSecretsPage = {
+  secrets: SecretManagerSecret[];
+  nextPageToken?: string;
+};
+
 /**
  * @see https://docs.cloud.google.com/secret-manager/docs/reference/rest/v1beta1/projects.secrets/list
  */
-export const listSecretManagerSecrets = async (
+export const listSecretManagerSecretsPage = async (
   projectId: string,
   accessToken: string,
-  onPageFetched?: (secrets: SecretManagerSecret[]) => void,
-): Promise<SecretManagerSecret[]> => {
-  const allSecrets: SecretManagerSecret[] = [];
-  let pageToken: string | undefined;
+  options: { pageSize: number; pageToken?: string },
+): Promise<SecretManagerSecretsPage> => {
+  const query = new URLSearchParams({
+    pageSize: options.pageSize.toString(),
+  });
+  if (options.pageToken) {
+    query.set("pageToken", options.pageToken);
+  }
 
-  do {
-    const query = new URLSearchParams();
-    if (pageToken) {
-      query.set("pageToken", pageToken);
-    }
+  const body = await fetchGoogleApi<SecretManagerSecretsResponse>(
+    `https://secretmanager.googleapis.com/v1beta1/projects/${projectId}/secrets?${query.toString()}`,
+    accessToken,
+  );
 
-    const suffix = query.toString();
-    const body = await fetchGoogleApi<SecretManagerSecretsResponse>(
-      `https://secretmanager.googleapis.com/v1beta1/projects/${projectId}/secrets${suffix ? `?${suffix}` : ""}`,
-      accessToken,
-    );
+  const secrets =
+    body.secrets?.map((secret) => {
+      // projects/{project}/secrets/{secretId}
+      const parts = secret.name.split("/");
+      const name = parts[parts.length - 1];
 
-    const secrets =
-      body.secrets?.map((secret) => {
-        // projects/{project}/secrets/{secretId}
-        const parts = secret.name.split("/");
-        const name = parts[parts.length - 1];
+      return {
+        id: secret.name,
+        name: name,
+        url: `https://console.cloud.google.com/security/secret-manager/secret/${name}?project=${projectId}`,
+      };
+    }) ?? [];
 
-        return {
-          id: secret.name,
-          name: name,
-          url: `https://console.cloud.google.com/security/secret-manager/secret/${name}?project=${projectId}`,
-        };
-      }) ?? [];
-
-    allSecrets.push(...secrets);
-    onPageFetched?.(allSecrets);
-
-    pageToken = body.nextPageToken;
-  } while (pageToken);
-
-  return allSecrets;
+  return {
+    secrets,
+    nextPageToken: body.nextPageToken,
+  };
 };

--- a/src/secret-manager/useSecretManager.ts
+++ b/src/secret-manager/useSecretManager.ts
@@ -1,24 +1,39 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { usePromise } from "@raycast/utils";
 import { useGoogleApi } from "../auth/google";
-import { listSecretManagerSecrets } from "./api";
+import { listSecretManagerSecretsPage } from "./api";
 import { SecretManagerSecret } from "./types";
+
+const SECRET_MANAGER_PAGE_SIZE = 50;
+const SECRET_MANAGER_LIMIT = 500;
 
 type SuccessResult = {
   secrets: SecretManagerSecret[];
   isLoading: boolean;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  isTruncated: boolean;
+  loadMore: () => Promise<void>;
   error: undefined;
 };
 
 type LoadingResult = {
   secrets: undefined;
   isLoading: true;
+  isLoadingMore: false;
+  hasMore: false;
+  isTruncated: false;
+  loadMore: () => Promise<void>;
   error: undefined;
 };
 
 type ErrorResult = {
   secrets: undefined;
   isLoading: false;
+  isLoadingMore: false;
+  hasMore: false;
+  isTruncated: false;
+  loadMore: () => Promise<void>;
   error: Error;
 };
 
@@ -26,25 +41,94 @@ type UseSecretManagerResult = SuccessResult | LoadingResult | ErrorResult;
 
 export const useSecretManager = (projectId: string): UseSecretManagerResult => {
   const { accessToken } = useGoogleApi();
-  const [progressiveSecrets, setProgressiveSecrets] = useState<SecretManagerSecret[]>([]);
+  const [secrets, setSecrets] = useState<SecretManagerSecret[]>([]);
+  const [nextPageToken, setNextPageToken] = useState<string | undefined>();
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isTruncated, setIsTruncated] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState<Error | undefined>();
+
+  const loadMore = useCallback(async () => {
+    if (!nextPageToken || isLoadingMore || isTruncated) {
+      return;
+    }
+
+    setIsLoadingMore(true);
+    setLoadMoreError(undefined);
+    try {
+      const page = await listSecretManagerSecretsPage(projectId, accessToken, {
+        pageSize: SECRET_MANAGER_PAGE_SIZE,
+        pageToken: nextPageToken,
+      });
+
+      const nextSecrets = [...secrets, ...page.secrets];
+      if (nextSecrets.length >= SECRET_MANAGER_LIMIT) {
+        setSecrets(nextSecrets.slice(0, SECRET_MANAGER_LIMIT));
+        setNextPageToken(undefined);
+        setIsTruncated(Boolean(page.nextPageToken) || nextSecrets.length > SECRET_MANAGER_LIMIT);
+      } else {
+        setSecrets(nextSecrets);
+        setNextPageToken(page.nextPageToken);
+      }
+    } catch (error) {
+      setLoadMoreError(error instanceof Error ? error : new Error(String(error)));
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [accessToken, secrets, isLoadingMore, isTruncated, nextPageToken, projectId]);
+
+  const noopLoadMore = useCallback(async () => undefined, []);
 
   const { isLoading, error } = usePromise(
     async (projId: string, token: string) => {
-      setProgressiveSecrets([]);
-      return await listSecretManagerSecrets(projId, token, (secrets) => {
-        setProgressiveSecrets([...secrets]);
+      setSecrets([]);
+      setNextPageToken(undefined);
+      setIsTruncated(false);
+      setLoadMoreError(undefined);
+
+      const page = await listSecretManagerSecretsPage(projId, token, {
+        pageSize: SECRET_MANAGER_PAGE_SIZE,
       });
+
+      setSecrets(page.secrets.slice(0, SECRET_MANAGER_LIMIT));
+      setNextPageToken(page.secrets.length >= SECRET_MANAGER_LIMIT ? undefined : page.nextPageToken);
+      setIsTruncated(page.secrets.length >= SECRET_MANAGER_LIMIT && Boolean(page.nextPageToken));
     },
     [projectId, accessToken],
   );
 
-  if (error) {
-    return { secrets: undefined, isLoading: false, error };
+  const resultError = error || loadMoreError;
+
+  if (resultError) {
+    return {
+      secrets: undefined,
+      isLoading: false,
+      isLoadingMore: false,
+      hasMore: false,
+      isTruncated: false,
+      loadMore: noopLoadMore,
+      error: resultError,
+    };
   }
 
-  if (isLoading && progressiveSecrets.length === 0) {
-    return { secrets: undefined, isLoading: true, error: undefined };
+  if (isLoading && secrets.length === 0) {
+    return {
+      secrets: undefined,
+      isLoading: true,
+      isLoadingMore: false,
+      hasMore: false,
+      isTruncated: false,
+      loadMore: noopLoadMore,
+      error: undefined,
+    };
   }
 
-  return { secrets: progressiveSecrets, isLoading, error: undefined };
+  return {
+    secrets,
+    isLoading,
+    isLoadingMore,
+    hasMore: Boolean(nextPageToken),
+    isTruncated,
+    loadMore,
+    error: undefined,
+  };
 };


### PR DESCRIPTION
## Summary

Apply bounded pagination to Secret Manager secrets, matching the established GCS pattern.

## Changes

### `src/secret-manager/api.ts`
- Replaced the eager all-pages `listSecretManagerSecrets()` function with `listSecretManagerSecretsPage()`
- New function accepts `{ pageSize, pageToken? }` options and returns a `SecretManagerSecretsPage` (secrets + nextPageToken) — no accumulation loop

### `src/secret-manager/useSecretManager.ts`
- Rewrote hook to explicit bounded pagination state: `nextPageToken`, `isLoadingMore`, `isTruncated`, `hasMore`
- Initial load fetches only the first page (50 secrets)
- `loadMore()` callback fetches the next page and appends to state
- Hard cap of 500 secrets enforced; `isTruncated` set when the cap is hit with more pages remaining
- Removed the accumulated-array callback pattern entirely

### `src/secret-manager/SecretManagerList.tsx`
- Added client-side `filtering` with `onSearchTextChange` and a placeholder explaining partial search scope
- `List.EmptyView` with contextual description (search miss vs. truncated vs. empty)
- "Load More Secrets" list item appears when `canLoadMore` is true
- "Secret List Truncated" list item appears when `isTruncated` is true
- Load-more action also available in each secret's `ActionPanel`

## Acceptance Criteria

- [x] Initial load does not fetch all pages eagerly
- [x] Pagination state is explicit and bounded
- [x] Users can explicitly load more secrets
- [x] Search and empty states clearly explain that only loaded secrets are searched
- [x] `npm run lint`, `npm run type-check`, and `npm run build` pass

closes #84