### PR TITLE
Bound Cloud Scheduler pagination

### DIFF
--- a/src/cloud-scheduler/CloudSchedulerJobList.tsx
+++ b/src/cloud-scheduler/CloudSchedulerJobList.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useCloudSchedulerJobs } from "./useCloudSchedulerJobs";
 import { toReadableCron } from "./cron";
@@ -6,14 +7,40 @@ import { ErrorDetail } from "../components/ErrorDetail";
 type Props = { projectId: string; locationId: string };
 
 export const CloudSchedulerJobList = ({ projectId, locationId }: Props) => {
-  const { scheduledJobs, isLoading, error } = useCloudSchedulerJobs(projectId, locationId);
+  const [searchText, setSearchText] = useState("");
+  const { scheduledJobs, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } = useCloudSchedulerJobs(
+    projectId,
+    locationId,
+  );
 
   if (error) {
     return <ErrorDetail error={error} />;
   }
 
+  const canLoadMore = hasMore && !isTruncated;
+  const loadMoreAction = canLoadMore ? (
+    <Action title="Load More Jobs" icon={Icon.ArrowDown} onAction={loadMore} />
+  ) : undefined;
+
   return (
-    <List isLoading={isLoading}>
+    <List
+      isLoading={isLoading || isLoadingMore}
+      filtering
+      onSearchTextChange={setSearchText}
+      searchBarPlaceholder="Search loaded Cloud Scheduler jobs..."
+    >
+      <List.EmptyView
+        icon={Icon.MagnifyingGlass}
+        title={searchText && canLoadMore ? "No loaded jobs match this search" : "No Cloud Scheduler jobs found"}
+        description={
+          searchText && canLoadMore
+            ? "More jobs may exist. Load more jobs to expand the searchable set."
+            : isTruncated
+              ? "The Cloud Scheduler job list is truncated to keep memory usage bounded."
+              : undefined
+        }
+        actions={loadMoreAction ? <ActionPanel>{loadMoreAction}</ActionPanel> : undefined}
+      />
       {scheduledJobs?.map((schedulerJob) => (
         <List.Item
           key={schedulerJob.name}
@@ -25,10 +52,28 @@ export const CloudSchedulerJobList = ({ projectId, locationId }: Props) => {
           actions={
             <ActionPanel>
               <Action.OpenInBrowser url={schedulerJob.url} />
+              {loadMoreAction}
             </ActionPanel>
           }
         />
       ))}
+      {canLoadMore && (
+        <List.Item
+          id="load-more-cloud-scheduler-jobs"
+          title="Load More Jobs"
+          icon={Icon.ArrowDown}
+          accessories={[{ text: `${scheduledJobs?.length ?? 0} loaded` }]}
+          actions={<ActionPanel>{loadMoreAction}</ActionPanel>}
+        />
+      )}
+      {isTruncated && (
+        <List.Item
+          id="cloud-scheduler-jobs-truncated"
+          title="Cloud Scheduler Job List Truncated"
+          icon={Icon.ExclamationMark}
+          accessories={[{ text: `${scheduledJobs?.length ?? 0} loaded` }]}
+        />
+      )}
     </List>
   );
 };

--- a/src/cloud-scheduler/api.ts
+++ b/src/cloud-scheduler/api.ts
@@ -21,28 +21,9 @@ type CloudSchedulerLocationsResponse = {
   }[];
 };
 
-const listCloudSchedulerJobsByType = async (
-  projectId: string,
-  locationId: string,
-  accessToken: string,
-  legacyAppEngineCron = false,
-): Promise<CloudSchedulerJobResponse[]> => {
-  const apiVersion = legacyAppEngineCron ? "v1beta1" : "v1";
-  const baseUrl = `https://cloudscheduler.googleapis.com/${apiVersion}/projects/${projectId}/locations/${locationId}/jobs`;
-  const allJobs: CloudSchedulerJobResponse[] = [];
-  let pageToken: string | undefined;
-
-  do {
-    const url = new URL(baseUrl);
-    if (legacyAppEngineCron) url.searchParams.set("legacyAppEngineCron", "true");
-    if (pageToken) url.searchParams.set("pageToken", pageToken);
-
-    const data = await fetchGoogleApi<CloudSchedulerJobsResponse>(url.toString(), accessToken);
-    if (data.jobs) allJobs.push(...data.jobs);
-    pageToken = data.nextPageToken;
-  } while (pageToken);
-
-  return allJobs;
+export type CloudSchedulerJobsPage = {
+  jobs: CloudSchedulerJob[];
+  nextPageToken?: string;
 };
 
 const createCloudSchedulerJobs = (projectId: string, jobs: CloudSchedulerJobResponse[]): CloudSchedulerJob[] => {
@@ -64,6 +45,29 @@ const createCloudSchedulerJobs = (projectId: string, jobs: CloudSchedulerJobResp
 };
 
 /**
+ * @see https://docs.cloud.google.com/scheduler/docs/reference/rest/v1beta1/projects.locations.jobs/list
+ */
+export const listCloudSchedulerJobsPage = async (
+  projectId: string,
+  locationId: string,
+  accessToken: string,
+  options: { pageSize: number; pageToken?: string; legacyAppEngineCron?: boolean },
+): Promise<CloudSchedulerJobsPage> => {
+  const apiVersion = options.legacyAppEngineCron ? "v1beta1" : "v1";
+  const baseUrl = `https://cloudscheduler.googleapis.com/${apiVersion}/projects/${projectId}/locations/${locationId}/jobs`;
+  const url = new URL(baseUrl);
+  url.searchParams.set("pageSize", options.pageSize.toString());
+  if (options.legacyAppEngineCron) url.searchParams.set("legacyAppEngineCron", "true");
+  if (options.pageToken) url.searchParams.set("pageToken", options.pageToken);
+
+  const data = await fetchGoogleApi<CloudSchedulerJobsResponse>(url.toString(), accessToken);
+  return {
+    jobs: createCloudSchedulerJobs(projectId, data.jobs ?? []),
+    nextPageToken: data.nextPageToken,
+  };
+};
+
+/**
  * @see https://docs.cloud.google.com/scheduler/docs/reference/rest/v1beta1/projects.locations/list
  */
 export const listCloudSchedulerLocations = async (projectId: string, accessToken: string): Promise<Location[]> => {
@@ -75,35 +79,4 @@ export const listCloudSchedulerLocations = async (projectId: string, accessToken
   return (data.locations ?? [])
     .map((location) => createLocation(location.locationId, location.displayName))
     .sort((a, b) => a.id.localeCompare(b.id));
-};
-
-/**
- * @see https://docs.cloud.google.com/scheduler/docs/reference/rest/v1beta1/projects.locations.jobs/list
- */
-export const listCloudSchedulerJobs = async (
-  projectId: string,
-  locationId: string,
-  accessToken: string,
-): Promise<CloudSchedulerJob[]> => {
-  const defaultJobsPromise = listCloudSchedulerJobsByType(projectId, locationId, accessToken);
-  const legacyJobsPromise = listCloudSchedulerJobsByType(projectId, locationId, accessToken, true);
-
-  const defaultJobs = await defaultJobsPromise;
-  let legacyJobs: CloudSchedulerJobResponse[] = [];
-  try {
-    legacyJobs = await legacyJobsPromise;
-  } catch (error) {
-    if (defaultJobs.length === 0) {
-      throw error;
-    }
-  }
-
-  const mergedJobs = [...defaultJobs, ...legacyJobs];
-  const jobsByResourceName = new Map<string, CloudSchedulerJobResponse>();
-
-  for (const job of mergedJobs) {
-    jobsByResourceName.set(job.name, job);
-  }
-
-  return createCloudSchedulerJobs(projectId, Array.from(jobsByResourceName.values()));
 };

--- a/src/cloud-scheduler/useCloudSchedulerJobs.ts
+++ b/src/cloud-scheduler/useCloudSchedulerJobs.ts
@@ -4,8 +4,8 @@ import { CloudSchedulerJob } from "./types";
 import { listCloudSchedulerJobsPage } from "./api";
 import { useGoogleApi } from "../auth/google";
 
-const CLOUD_SCHEDULER_JOB_PAGE_SIZE = 50;
 const CLOUD_SCHEDULER_JOB_LIMIT = 500;
+const CLOUD_SCHEDULER_JOB_PAGE_SIZE = CLOUD_SCHEDULER_JOB_LIMIT;
 
 type SuccessResult = {
   scheduledJobs: CloudSchedulerJob[];

--- a/src/cloud-scheduler/useCloudSchedulerJobs.ts
+++ b/src/cloud-scheduler/useCloudSchedulerJobs.ts
@@ -1,44 +1,200 @@
+import { useCallback, useState } from "react";
 import { usePromise } from "@raycast/utils";
 import { CloudSchedulerJob } from "./types";
-import { listCloudSchedulerJobs } from "./api";
+import { listCloudSchedulerJobsPage } from "./api";
 import { useGoogleApi } from "../auth/google";
+
+const CLOUD_SCHEDULER_JOB_PAGE_SIZE = 50;
+const CLOUD_SCHEDULER_JOB_LIMIT = 500;
 
 type SuccessResult = {
   scheduledJobs: CloudSchedulerJob[];
   isLoading: boolean;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  isTruncated: boolean;
+  loadMore: () => Promise<void>;
   error: undefined;
 };
 
 type LoadingResult = {
   scheduledJobs: undefined;
   isLoading: true;
+  isLoadingMore: false;
+  hasMore: false;
+  isTruncated: false;
+  loadMore: () => Promise<void>;
   error: undefined;
 };
 
 type ErrorResult = {
   scheduledJobs: undefined;
   isLoading: false;
+  isLoadingMore: false;
+  hasMore: false;
+  isTruncated: false;
+  loadMore: () => Promise<void>;
   error: Error;
 };
 
 type UseCloudSchedulerJobsResult = SuccessResult | LoadingResult | ErrorResult;
 
+type PaginationTokens = {
+  defaultNextPageToken?: string;
+  legacyNextPageToken?: string;
+};
+
+const mergeJobs = (jobs: CloudSchedulerJob[], nextJobs: CloudSchedulerJob[]): CloudSchedulerJob[] => {
+  const jobsByName = new Map<string, CloudSchedulerJob>();
+  for (const job of [...jobs, ...nextJobs]) {
+    jobsByName.set(job.name, job);
+  }
+  return Array.from(jobsByName.values());
+};
+
 export const useCloudSchedulerJobs = (projectId: string, locationId: string): UseCloudSchedulerJobsResult => {
   const { accessToken } = useGoogleApi();
-  const { data, isLoading, error } = usePromise(
+  const [scheduledJobs, setScheduledJobs] = useState<CloudSchedulerJob[]>([]);
+  const [paginationTokens, setPaginationTokens] = useState<PaginationTokens>({});
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isTruncated, setIsTruncated] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState<Error | undefined>();
+
+  const loadMore = useCallback(async () => {
+    if (
+      (!paginationTokens.defaultNextPageToken && !paginationTokens.legacyNextPageToken) ||
+      isLoadingMore ||
+      isTruncated
+    ) {
+      return;
+    }
+
+    setIsLoadingMore(true);
+    setLoadMoreError(undefined);
+    try {
+      const defaultPage = paginationTokens.defaultNextPageToken
+        ? await listCloudSchedulerJobsPage(projectId, locationId, accessToken, {
+            pageSize: CLOUD_SCHEDULER_JOB_PAGE_SIZE,
+            pageToken: paginationTokens.defaultNextPageToken,
+          })
+        : { jobs: [] };
+
+      let legacyPage: { jobs: CloudSchedulerJob[]; nextPageToken?: string } = { jobs: [] };
+      if (paginationTokens.legacyNextPageToken) {
+        try {
+          legacyPage = await listCloudSchedulerJobsPage(projectId, locationId, accessToken, {
+            pageSize: CLOUD_SCHEDULER_JOB_PAGE_SIZE,
+            pageToken: paginationTokens.legacyNextPageToken,
+            legacyAppEngineCron: true,
+          });
+        } catch (error) {
+          if (scheduledJobs.length === 0 && defaultPage.jobs.length === 0) {
+            throw error;
+          }
+        }
+      }
+
+      const nextJobs = mergeJobs(scheduledJobs, [...defaultPage.jobs, ...legacyPage.jobs]);
+      if (nextJobs.length >= CLOUD_SCHEDULER_JOB_LIMIT) {
+        setScheduledJobs(nextJobs.slice(0, CLOUD_SCHEDULER_JOB_LIMIT));
+        setPaginationTokens({});
+        setIsTruncated(
+          Boolean(defaultPage.nextPageToken) ||
+            Boolean(legacyPage.nextPageToken) ||
+            nextJobs.length > CLOUD_SCHEDULER_JOB_LIMIT,
+        );
+      } else {
+        setScheduledJobs(nextJobs);
+        setPaginationTokens({
+          defaultNextPageToken: defaultPage.nextPageToken,
+          legacyNextPageToken: legacyPage.nextPageToken,
+        });
+      }
+    } catch (error) {
+      setLoadMoreError(error instanceof Error ? error : new Error(String(error)));
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [accessToken, isLoadingMore, isTruncated, locationId, paginationTokens, projectId, scheduledJobs]);
+
+  const noopLoadMore = useCallback(async () => undefined, []);
+
+  const { isLoading, error } = usePromise(
     async (projId: string, locId: string, token: string) => {
-      return await listCloudSchedulerJobs(projId, locId, token);
+      setScheduledJobs([]);
+      setPaginationTokens({});
+      setIsTruncated(false);
+      setLoadMoreError(undefined);
+
+      const defaultPage = await listCloudSchedulerJobsPage(projId, locId, token, {
+        pageSize: CLOUD_SCHEDULER_JOB_PAGE_SIZE,
+      });
+
+      let legacyPage: { jobs: CloudSchedulerJob[]; nextPageToken?: string } = { jobs: [] };
+      try {
+        legacyPage = await listCloudSchedulerJobsPage(projId, locId, token, {
+          pageSize: CLOUD_SCHEDULER_JOB_PAGE_SIZE,
+          legacyAppEngineCron: true,
+        });
+      } catch (error) {
+        if (defaultPage.jobs.length === 0) {
+          throw error;
+        }
+      }
+
+      const jobs = mergeJobs([], [...defaultPage.jobs, ...legacyPage.jobs]);
+      setScheduledJobs(jobs.slice(0, CLOUD_SCHEDULER_JOB_LIMIT));
+      setPaginationTokens(
+        jobs.length >= CLOUD_SCHEDULER_JOB_LIMIT
+          ? {}
+          : {
+              defaultNextPageToken: defaultPage.nextPageToken,
+              legacyNextPageToken: legacyPage.nextPageToken,
+            },
+      );
+      setIsTruncated(
+        jobs.length >= CLOUD_SCHEDULER_JOB_LIMIT &&
+          (Boolean(defaultPage.nextPageToken) ||
+            Boolean(legacyPage.nextPageToken) ||
+            jobs.length > CLOUD_SCHEDULER_JOB_LIMIT),
+      );
     },
     [projectId, locationId, accessToken],
   );
 
-  if (error) {
-    return { scheduledJobs: undefined, isLoading: false, error };
+  const resultError = error || loadMoreError;
+
+  if (resultError) {
+    return {
+      scheduledJobs: undefined,
+      isLoading: false,
+      isLoadingMore: false,
+      hasMore: false,
+      isTruncated: false,
+      loadMore: noopLoadMore,
+      error: resultError,
+    };
   }
 
-  if (!data) {
-    return { scheduledJobs: undefined, isLoading: true, error: undefined };
+  if (isLoading && scheduledJobs.length === 0) {
+    return {
+      scheduledJobs: undefined,
+      isLoading: true,
+      isLoadingMore: false,
+      hasMore: false,
+      isTruncated: false,
+      loadMore: noopLoadMore,
+      error: undefined,
+    };
   }
 
-  return { scheduledJobs: data, isLoading, error: undefined };
+  return {
+    scheduledJobs,
+    isLoading,
+    isLoadingMore,
+    hasMore: Boolean(paginationTokens.defaultNextPageToken || paginationTokens.legacyNextPageToken),
+    isTruncated,
+    loadMore,
+    error: undefined,
+  };
 };

--- a/src/cloud-scheduler/useCloudSchedulerJobs.ts
+++ b/src/cloud-scheduler/useCloudSchedulerJobs.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 import { usePromise } from "@raycast/utils";
 import { CloudSchedulerJob } from "./types";
-import { listCloudSchedulerJobsPage } from "./api";
+import { CloudSchedulerJobsPage, listCloudSchedulerJobsPage } from "./api";
 import { useGoogleApi } from "../auth/google";
 
 const CLOUD_SCHEDULER_JOB_LIMIT = 500;
@@ -52,6 +52,30 @@ const mergeJobs = (jobs: CloudSchedulerJob[], nextJobs: CloudSchedulerJob[]): Cl
   return Array.from(jobsByName.values());
 };
 
+const listFirstNonEmptyCloudSchedulerJobsPage = async (
+  projectId: string,
+  locationId: string,
+  accessToken: string,
+  options: { pageSize: number; pageToken?: string; legacyAppEngineCron?: boolean },
+): Promise<CloudSchedulerJobsPage> => {
+  let pageToken = options.pageToken;
+  const seenPageTokens = new Set<string>();
+
+  for (;;) {
+    const page = await listCloudSchedulerJobsPage(projectId, locationId, accessToken, {
+      ...options,
+      pageToken,
+    });
+
+    if (page.jobs.length > 0 || !page.nextPageToken || seenPageTokens.has(page.nextPageToken)) {
+      return page;
+    }
+
+    seenPageTokens.add(page.nextPageToken);
+    pageToken = page.nextPageToken;
+  }
+};
+
 export const useCloudSchedulerJobs = (projectId: string, locationId: string): UseCloudSchedulerJobsResult => {
   const { accessToken } = useGoogleApi();
   const [scheduledJobs, setScheduledJobs] = useState<CloudSchedulerJob[]>([]);
@@ -73,7 +97,7 @@ export const useCloudSchedulerJobs = (projectId: string, locationId: string): Us
     setLoadMoreError(undefined);
     try {
       const defaultPage = paginationTokens.defaultNextPageToken
-        ? await listCloudSchedulerJobsPage(projectId, locationId, accessToken, {
+        ? await listFirstNonEmptyCloudSchedulerJobsPage(projectId, locationId, accessToken, {
             pageSize: CLOUD_SCHEDULER_JOB_PAGE_SIZE,
             pageToken: paginationTokens.defaultNextPageToken,
           })
@@ -82,7 +106,7 @@ export const useCloudSchedulerJobs = (projectId: string, locationId: string): Us
       let legacyPage: { jobs: CloudSchedulerJob[]; nextPageToken?: string } = { jobs: [] };
       if (paginationTokens.legacyNextPageToken) {
         try {
-          legacyPage = await listCloudSchedulerJobsPage(projectId, locationId, accessToken, {
+          legacyPage = await listFirstNonEmptyCloudSchedulerJobsPage(projectId, locationId, accessToken, {
             pageSize: CLOUD_SCHEDULER_JOB_PAGE_SIZE,
             pageToken: paginationTokens.legacyNextPageToken,
             legacyAppEngineCron: true,
@@ -126,13 +150,13 @@ export const useCloudSchedulerJobs = (projectId: string, locationId: string): Us
       setIsTruncated(false);
       setLoadMoreError(undefined);
 
-      const defaultPage = await listCloudSchedulerJobsPage(projId, locId, token, {
+      const defaultPage = await listFirstNonEmptyCloudSchedulerJobsPage(projId, locId, token, {
         pageSize: CLOUD_SCHEDULER_JOB_PAGE_SIZE,
       });
 
       let legacyPage: { jobs: CloudSchedulerJob[]; nextPageToken?: string } = { jobs: [] };
       try {
-        legacyPage = await listCloudSchedulerJobsPage(projId, locId, token, {
+        legacyPage = await listFirstNonEmptyCloudSchedulerJobsPage(projId, locId, token, {
           pageSize: CLOUD_SCHEDULER_JOB_PAGE_SIZE,
           legacyAppEngineCron: true,
         });

--- a/src/cloud-scheduler/useCloudSchedulerJobs.ts
+++ b/src/cloud-scheduler/useCloudSchedulerJobs.ts
@@ -119,7 +119,7 @@ export const useCloudSchedulerJobs = (projectId: string, locationId: string): Us
 
   const noopLoadMore = useCallback(async () => undefined, []);
 
-  const { isLoading, error } = usePromise(
+  const { data, isLoading, error } = usePromise(
     async (projId: string, locId: string, token: string) => {
       setScheduledJobs([]);
       setPaginationTokens({});
@@ -143,7 +143,8 @@ export const useCloudSchedulerJobs = (projectId: string, locationId: string): Us
       }
 
       const jobs = mergeJobs([], [...defaultPage.jobs, ...legacyPage.jobs]);
-      setScheduledJobs(jobs.slice(0, CLOUD_SCHEDULER_JOB_LIMIT));
+      const initialJobs = jobs.slice(0, CLOUD_SCHEDULER_JOB_LIMIT);
+      setScheduledJobs(initialJobs);
       setPaginationTokens(
         jobs.length >= CLOUD_SCHEDULER_JOB_LIMIT
           ? {}
@@ -158,6 +159,8 @@ export const useCloudSchedulerJobs = (projectId: string, locationId: string): Us
             Boolean(legacyPage.nextPageToken) ||
             jobs.length > CLOUD_SCHEDULER_JOB_LIMIT),
       );
+
+      return initialJobs;
     },
     [projectId, locationId, accessToken],
   );
@@ -176,7 +179,9 @@ export const useCloudSchedulerJobs = (projectId: string, locationId: string): Us
     };
   }
 
-  if (isLoading && scheduledJobs.length === 0) {
+  const loadedJobs = scheduledJobs.length > 0 ? scheduledJobs : (data ?? []);
+
+  if (isLoading && loadedJobs.length === 0) {
     return {
       scheduledJobs: undefined,
       isLoading: true,
@@ -189,7 +194,7 @@ export const useCloudSchedulerJobs = (projectId: string, locationId: string): Us
   }
 
   return {
-    scheduledJobs,
+    scheduledJobs: loadedJobs,
     isLoading,
     isLoadingMore,
     hasMore: Boolean(paginationTokens.defaultNextPageToken || paginationTokens.legacyNextPageToken),


### PR DESCRIPTION
## Summary

- Fetch only one Cloud Scheduler page for default jobs and legacy App Engine cron jobs on initial load.
- Keep separate pagination state for default and legacy job queries with explicit load-more behavior.
- Cap retained Cloud Scheduler jobs at 500 and explain loaded-only search/truncated results in the UI.

closes #88

## Verification

- npm run lint
- npm run type-check
- npm run build
