### PR TITLE
Fix invalid AlloyDB cluster console links

### DIFF
--- a/src/alloydb/api.ts
+++ b/src/alloydb/api.ts
@@ -32,7 +32,7 @@ export const listAlloyDbClusters = async (projectId: string, accessToken: string
         displayName: cluster.displayName,
         region,
         state: cluster.state,
-        url: `https://console.cloud.google.com/alloydb/clusters/${region}/${clusterId}?project=${projectId}`,
+        url: `https://console.cloud.google.com/alloydb/locations/${region}/clusters/${clusterId}?project=${projectId}`,
       };
     }) ?? [];
 


### PR DESCRIPTION
### Motivation
- Fix incorrect AlloyDB cluster deep links so the console URL matches the expected `/alloydb/locations/{region}/clusters/{clusterName}` format referenced in issue #97.

### Description
- Update `src/alloydb/api.ts` to construct cluster URLs as `https://console.cloud.google.com/alloydb/locations/${region}/clusters/${clusterId}?project=${projectId}`, preserving the `project` query parameter and including `closes #97` for automatic issue closing.

### Testing
- Ran `npm run lint` (failed due to external Raycast schema/author validation network check in this environment), `npm run type-check` (succeeded), and `npm run build` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f08a10bf08324bec13a5f1dbe31ba)