### PR TITLE
Add paginated Pub/Sub listing with Load More and truncation handling

### DIFF
--- a/src/pubsub/PubSubSubscriptionList.tsx
+++ b/src/pubsub/PubSubSubscriptionList.tsx
@@ -7,14 +7,25 @@ type Props = {
 };
 
 export const PubSubSubscriptionList = (props: Props) => {
-  const { resources, isLoading, error } = usePubSubResources(props.projectId);
+  const { resources, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } = usePubSubResources(
+    props.projectId,
+  );
 
   if (error) {
     return <ErrorDetail error={error} />;
   }
 
+  const canLoadMore = hasMore && !isTruncated;
+
   return (
-    <List isLoading={isLoading}>
+    <List
+      isLoading={isLoading || isLoadingMore}
+      searchBarPlaceholder={
+        canLoadMore
+          ? "Search loaded topics/subscriptions. More resources are available via Load More."
+          : "Search loaded topics/subscriptions"
+      }
+    >
       {resources?.map((resource) => (
         <List.Item
           key={`${resource.resourceType}/${resource.name}`}
@@ -33,10 +44,29 @@ export const PubSubSubscriptionList = (props: Props) => {
           actions={
             <ActionPanel>
               <Action.OpenInBrowser url={resource.url} />
+              {canLoadMore && <Action title="Load More Pub/Sub Resources" icon={Icon.ArrowDown} onAction={loadMore} />}
             </ActionPanel>
           }
         />
       ))}
+      {canLoadMore && (
+        <List.Item
+          key="load-more-pubsub"
+          title="Load More Pub/Sub Resources"
+          icon={Icon.ArrowDown}
+          actions={
+            <ActionPanel>
+              <Action title="Load More Pub/Sub Resources" icon={Icon.ArrowDown} onAction={loadMore} />
+            </ActionPanel>
+          }
+        />
+      )}
+      {isTruncated && (
+        <List.EmptyView
+          title="Resource list truncated"
+          description="The Pub/Sub resource list is truncated to keep memory usage bounded."
+        />
+      )}
     </List>
   );
 };

--- a/src/pubsub/api.ts
+++ b/src/pubsub/api.ts
@@ -2,6 +2,7 @@ import { fetchGoogleApi } from "../auth/api";
 import { createPubSubSubscription, createPubSubTopic, PubSubSubscription, PubSubTopic } from "./types";
 
 type PubSubSubscriptionsResponse = {
+  nextPageToken?: string;
   subscriptions?: {
     name: string;
     topic: string;
@@ -11,54 +12,103 @@ type PubSubSubscriptionsResponse = {
   }[];
 };
 
+type ListPubSubSubscriptionsPageOptions = {
+  pageSize: number;
+  pageToken?: string;
+};
+
+export type PubSubSubscriptionsPage = {
+  subscriptions: PubSubSubscription[];
+  nextPageToken?: string;
+};
+
 /**
  * @see https://docs.cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/list
  */
-export const listPubSubSubscriptions = async (
+export const listPubSubSubscriptionsPage = async (
   projectId: string,
   accessToken: string,
-): Promise<PubSubSubscription[]> => {
-  const body = await fetchGoogleApi<PubSubSubscriptionsResponse>(
-    `https://pubsub.googleapis.com/v1/projects/${projectId}/subscriptions`,
-    accessToken,
-  );
+  options: ListPubSubSubscriptionsPageOptions,
+): Promise<PubSubSubscriptionsPage> => {
+  const apiUrl = new URL(`https://pubsub.googleapis.com/v1/projects/${projectId}/subscriptions`);
+  apiUrl.searchParams.append("pageSize", String(options.pageSize));
+  if (options.pageToken) {
+    apiUrl.searchParams.append("pageToken", options.pageToken);
+  }
 
-  return (
-    body.subscriptions?.map((subscription) => {
-      return createPubSubSubscription({
-        projectId,
-        // projects/PROJECT_ID/subscriptions/SUBSCRIPTION_ID
-        name: subscription.name.split("/")[3] ?? "",
-        // projects/PROJECT_ID/topics/TOPIC_ID
-        topic: subscription.topic.split("/")[3] ?? "",
-        subscriptionType: subscription.pushConfig === undefined ? "Pull" : "Push",
-      });
-    }) ?? []
-  );
+  const body = await fetchGoogleApi<PubSubSubscriptionsResponse>(apiUrl.toString(), accessToken);
+
+  return {
+    subscriptions:
+      body.subscriptions?.map((subscription) => {
+        return createPubSubSubscription({
+          projectId,
+          // projects/PROJECT_ID/subscriptions/SUBSCRIPTION_ID
+          name: subscription.name.split("/")[3] ?? "",
+          // projects/PROJECT_ID/topics/TOPIC_ID
+          topic: subscription.topic.split("/")[3] ?? "",
+          subscriptionType: subscription.pushConfig === undefined ? "Pull" : "Push",
+        });
+      }) ?? [],
+    nextPageToken: body.nextPageToken,
+  };
 };
 
 type PubSubTopicsResponse = {
+  nextPageToken?: string;
   topics?: {
     name: string;
   }[];
 };
 
+type ListPubSubTopicsPageOptions = {
+  pageSize: number;
+  pageToken?: string;
+};
+
+export type PubSubTopicsPage = {
+  topics: PubSubTopic[];
+  nextPageToken?: string;
+};
+
 /**
  * @see https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/list
  */
-export const listPubSubTopics = async (projectId: string, accessToken: string): Promise<PubSubTopic[]> => {
-  const body = await fetchGoogleApi<PubSubTopicsResponse>(
-    `https://pubsub.googleapis.com/v1/projects/${projectId}/topics`,
-    accessToken,
-  );
+export const listPubSubTopicsPage = async (
+  projectId: string,
+  accessToken: string,
+  options: ListPubSubTopicsPageOptions,
+): Promise<PubSubTopicsPage> => {
+  const apiUrl = new URL(`https://pubsub.googleapis.com/v1/projects/${projectId}/topics`);
+  apiUrl.searchParams.append("pageSize", String(options.pageSize));
+  if (options.pageToken) {
+    apiUrl.searchParams.append("pageToken", options.pageToken);
+  }
 
-  return (
-    body.topics?.map((topic) => {
-      return createPubSubTopic({
-        projectId,
-        // projects/PROJECT_ID/topics/TOPIC_ID
-        name: topic.name.split("/")[3] ?? "",
-      });
-    }) ?? []
-  );
+  const body = await fetchGoogleApi<PubSubTopicsResponse>(apiUrl.toString(), accessToken);
+
+  return {
+    topics:
+      body.topics?.map((topic) => {
+        return createPubSubTopic({
+          projectId,
+          // projects/PROJECT_ID/topics/TOPIC_ID
+          name: topic.name.split("/")[3] ?? "",
+        });
+      }) ?? [],
+    nextPageToken: body.nextPageToken,
+  };
+};
+
+export const listPubSubSubscriptions = async (
+  projectId: string,
+  accessToken: string,
+): Promise<PubSubSubscription[]> => {
+  const page = await listPubSubSubscriptionsPage(projectId, accessToken, { pageSize: 1000 });
+  return page.subscriptions;
+};
+
+export const listPubSubTopics = async (projectId: string, accessToken: string): Promise<PubSubTopic[]> => {
+  const page = await listPubSubTopicsPage(projectId, accessToken, { pageSize: 1000 });
+  return page.topics;
 };

--- a/src/pubsub/usePubSubResources.ts
+++ b/src/pubsub/usePubSubResources.ts
@@ -1,55 +1,169 @@
+import { useCallback, useMemo, useState } from "react";
+import { usePromise } from "@raycast/utils";
+import { useGoogleApi } from "../auth/google";
+import { listPubSubSubscriptionsPage, listPubSubTopicsPage } from "./api";
 import { PubSubResource } from "./types";
-import { usePubSubSubscriptions } from "./usePubSubSubscriptions";
-import { usePubSubTopics } from "./usePubSubTopics";
+
+const PUBSUB_PAGE_SIZE = 50;
+const PUBSUB_RESOURCE_LIMIT = 500;
 
 type SuccessResult = {
   resources: PubSubResource[];
   isLoading: boolean;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  isTruncated: boolean;
+  loadMore: () => Promise<void>;
   error: undefined;
 };
 
 type LoadingResult = {
   resources: undefined;
   isLoading: true;
+  isLoadingMore: false;
+  hasMore: false;
+  isTruncated: false;
+  loadMore: () => Promise<void>;
   error: undefined;
 };
 
 type ErrorResult = {
   resources: undefined;
   isLoading: false;
+  isLoadingMore: false;
+  hasMore: false;
+  isTruncated: false;
+  loadMore: () => Promise<void>;
   error: Error;
 };
 
 type UsePubSubResourcesResult = SuccessResult | LoadingResult | ErrorResult;
 
 export const usePubSubResources = (projectId: string): UsePubSubResourcesResult => {
-  const {
-    subscriptions,
-    isLoading: isLoadingSubscriptions,
-    error: errorSubscriptions,
-  } = usePubSubSubscriptions(projectId);
-  const { topics, isLoading: isLoadingTopics, error: errorTopics } = usePubSubTopics(projectId);
+  const { accessToken } = useGoogleApi();
 
-  const error = errorSubscriptions || errorTopics;
-  if (error) {
+  const [resources, setResources] = useState<PubSubResource[]>([]);
+  const [topicNextPageToken, setTopicNextPageToken] = useState<string | undefined>();
+  const [subscriptionNextPageToken, setSubscriptionNextPageToken] = useState<string | undefined>();
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isTruncated, setIsTruncated] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState<Error | undefined>();
+
+  const hasMore = useMemo(
+    () => Boolean(topicNextPageToken) || Boolean(subscriptionNextPageToken),
+    [subscriptionNextPageToken, topicNextPageToken],
+  );
+
+  const loadMore = useCallback(async () => {
+    if (!hasMore || isLoadingMore || isTruncated) {
+      return;
+    }
+
+    setIsLoadingMore(true);
+    setLoadMoreError(undefined);
+
+    try {
+      const [topicsPage, subscriptionsPage] = await Promise.all([
+        topicNextPageToken
+          ? listPubSubTopicsPage(projectId, accessToken, { pageSize: PUBSUB_PAGE_SIZE, pageToken: topicNextPageToken })
+          : Promise.resolve({ topics: [], nextPageToken: undefined }),
+        subscriptionNextPageToken
+          ? listPubSubSubscriptionsPage(projectId, accessToken, {
+              pageSize: PUBSUB_PAGE_SIZE,
+              pageToken: subscriptionNextPageToken,
+            })
+          : Promise.resolve({ subscriptions: [], nextPageToken: undefined }),
+      ]);
+
+      const mergedResources = [...resources, ...topicsPage.topics, ...subscriptionsPage.subscriptions];
+      if (mergedResources.length >= PUBSUB_RESOURCE_LIMIT) {
+        setResources(mergedResources.slice(0, PUBSUB_RESOURCE_LIMIT));
+        setTopicNextPageToken(undefined);
+        setSubscriptionNextPageToken(undefined);
+        setIsTruncated(Boolean(topicsPage.nextPageToken) || Boolean(subscriptionsPage.nextPageToken));
+      } else {
+        setResources(mergedResources);
+        setTopicNextPageToken(topicsPage.nextPageToken);
+        setSubscriptionNextPageToken(subscriptionsPage.nextPageToken);
+      }
+    } catch (error) {
+      setLoadMoreError(error instanceof Error ? error : new Error(String(error)));
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [
+    accessToken,
+    hasMore,
+    isLoadingMore,
+    isTruncated,
+    projectId,
+    resources,
+    subscriptionNextPageToken,
+    topicNextPageToken,
+  ]);
+
+  const noopLoadMore = useCallback(async () => undefined, []);
+
+  const { isLoading, error } = usePromise(
+    async (projId: string, token: string) => {
+      setResources([]);
+      setTopicNextPageToken(undefined);
+      setSubscriptionNextPageToken(undefined);
+      setIsTruncated(false);
+      setLoadMoreError(undefined);
+
+      const [topicsPage, subscriptionsPage] = await Promise.all([
+        listPubSubTopicsPage(projId, token, { pageSize: PUBSUB_PAGE_SIZE }),
+        listPubSubSubscriptionsPage(projId, token, { pageSize: PUBSUB_PAGE_SIZE }),
+      ]);
+
+      const nextResources = [...topicsPage.topics, ...subscriptionsPage.subscriptions];
+      if (nextResources.length >= PUBSUB_RESOURCE_LIMIT) {
+        setResources(nextResources.slice(0, PUBSUB_RESOURCE_LIMIT));
+        setTopicNextPageToken(undefined);
+        setSubscriptionNextPageToken(undefined);
+        setIsTruncated(Boolean(topicsPage.nextPageToken) || Boolean(subscriptionsPage.nextPageToken));
+      } else {
+        setResources(nextResources);
+        setTopicNextPageToken(topicsPage.nextPageToken);
+        setSubscriptionNextPageToken(subscriptionsPage.nextPageToken);
+      }
+    },
+    [projectId, accessToken],
+  );
+
+  const resultError = error || loadMoreError;
+  if (resultError) {
     return {
       resources: undefined,
       isLoading: false,
-      error: error,
+      isLoadingMore: false,
+      hasMore: false,
+      isTruncated: false,
+      loadMore: noopLoadMore,
+      error: resultError,
     };
   }
 
-  if (isLoadingSubscriptions || isLoadingTopics || !subscriptions || !topics) {
+  if (isLoading && resources.length === 0) {
     return {
       resources: undefined,
       isLoading: true,
+      isLoadingMore: false,
+      hasMore: false,
+      isTruncated: false,
+      loadMore: noopLoadMore,
       error: undefined,
     };
   }
 
   return {
-    resources: [...topics, ...subscriptions],
-    isLoading: false,
+    resources,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    isTruncated,
+    loadMore,
     error: undefined,
   };
 };


### PR DESCRIPTION
### Motivation

- Prevent unbounded memory usage when enumerating Pub/Sub topics and subscriptions by paginating API requests.  
- Provide a user-visible "Load More" action to incrementally fetch additional resources.  
- Surface when resource lists are truncated and avoid silently dropping items.

### Description

- Add paged API helpers `listPubSubTopicsPage` and `listPubSubSubscriptionsPage` that return page data and `nextPageToken`, and keep backward-compatible wrappers `listPubSubTopics` and `listPubSubSubscriptions`.  
- Replace previous aggregated hook with `usePubSubResources`, which manages paging state, merging pages, a `loadMore` function, `isLoadingMore`, `hasMore`, and `isTruncated`, and enforces a `PUBSUB_RESOURCE_LIMIT`.  
- Update `PubSubSubscriptionList` to use the new hook, show combined loading state, display a contextual search placeholder when more resources are available, add a per-item and list "Load More Pub/Sub Resources" action/item, and render an empty view when the list is truncated.  
- Preserve existing resource shapes and add safe guards for page tokens and errors when loading more pages.

### Testing

- Ran TypeScript type checking (`tsc` / `npm run build`) to validate types and compilation, which succeeded.  
- Executed the repository's automated test suite (`npm test`) where available, and existing tests passed.  
- No new unit tests were added in this change.

closes #87

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f0e5d6e508324a84c3e7b83e05bbd)