### PR TITLE
Fix Cloud Run list pagination

### DIFF
--- a/src/cloud-run/CloudRunServicesList.tsx
+++ b/src/cloud-run/CloudRunServicesList.tsx
@@ -1,22 +1,27 @@
+import { useState } from "react";
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { OpenCloudLoggingAction } from "../actions/cloud-logging/OpenCloudLoggingAction";
 import { useCloudRunDeployments } from "./useCloudRunDeployments";
 import { ErrorDetail } from "../components/ErrorDetail";
+import { useLoadMoreOnSearch } from "../hooks/useLoadMoreOnSearch";
 
 type Props = {
   projectId: string;
 };
 
 export const CloudRunServicesList = (props: Props) => {
+  const [searchText, setSearchText] = useState("");
   const { deployments, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } = useCloudRunDeployments(
     props.projectId,
   );
+
+  const canLoadMore = hasMore && !isTruncated;
+  useLoadMoreOnSearch({ searchText, canLoadMore, isLoading, isLoadingMore, loadMore });
 
   if (error) {
     return <ErrorDetail error={error} />;
   }
 
-  const canLoadMore = hasMore && !isTruncated;
   const loadMoreAction = canLoadMore ? (
     <Action title="Load More Deployments" icon={Icon.ArrowDown} onAction={loadMore} />
   ) : null;
@@ -35,13 +40,15 @@ export const CloudRunServicesList = (props: Props) => {
             }
           : undefined
       }
+      filtering
+      onSearchTextChange={setSearchText}
       searchBarPlaceholder="Search loaded deployments..."
     >
       <List.EmptyView
         icon={Icon.MagnifyingGlass}
-        title={hasMore ? "No loaded deployments match this search" : "No deployments found"}
+        title={searchText && hasMore ? "No loaded deployments match this search" : "No deployments found"}
         description={
-          hasMore
+          searchText && hasMore
             ? "More deployments may exist. Load more deployments to expand the searchable set."
             : isTruncated
               ? "The deployment list is truncated to keep memory usage bounded."

--- a/src/cloud-run/CloudRunServicesList.tsx
+++ b/src/cloud-run/CloudRunServicesList.tsx
@@ -16,12 +16,27 @@ export const CloudRunServicesList = (props: Props) => {
     return <ErrorDetail error={error} />;
   }
 
-  const loadMoreAction = hasMore ? (
+  const canLoadMore = hasMore && !isTruncated;
+  const loadMoreAction = canLoadMore ? (
     <Action title="Load More Deployments" icon={Icon.ArrowDown} onAction={loadMore} />
   ) : null;
 
   return (
-    <List isLoading={isLoading || isLoadingMore} searchBarPlaceholder="Search loaded deployments...">
+    <List
+      isLoading={isLoading || isLoadingMore}
+      pagination={
+        canLoadMore
+          ? {
+              pageSize: 50,
+              hasMore: canLoadMore,
+              onLoadMore: () => {
+                void loadMore();
+              },
+            }
+          : undefined
+      }
+      searchBarPlaceholder="Search loaded deployments..."
+    >
       <List.EmptyView
         icon={Icon.MagnifyingGlass}
         title={hasMore ? "No loaded deployments match this search" : "No deployments found"}
@@ -68,7 +83,7 @@ export const CloudRunServicesList = (props: Props) => {
           />
         );
       })}
-      {hasMore && (
+      {canLoadMore && (
         <List.Item
           id="load-more-cloud-run-deployments"
           title="Load More Deployments"

--- a/src/cloud-run/api.ts
+++ b/src/cloud-run/api.ts
@@ -1,4 +1,5 @@
 import { fetchGoogleApi } from "../auth/api";
+import { createLocation, Location } from "../region/types";
 import { CloudRunDeployment, createCloudRunDeployment } from "./types";
 
 type CloudRunServicesResponse = {
@@ -14,6 +15,13 @@ type CloudRunServicesResponse = {
     };
   }[];
   nextPageToken?: string;
+};
+
+type CloudRunLocationsResponse = {
+  locations?: {
+    locationId: string;
+    displayName?: string;
+  }[];
 };
 
 type CloudRunJobsResponse = {
@@ -58,6 +66,7 @@ export type CloudRunDeploymentPage = {
  */
 export const listCloudRunServicesPage = async (
   projectId: string,
+  locationId: string,
   accessToken: string,
   options: { pageSize: number; pageToken?: string },
 ): Promise<CloudRunDeploymentPage> => {
@@ -70,7 +79,7 @@ export const listCloudRunServicesPage = async (
 
   const suffix = query.toString();
   const body = await fetchGoogleApi<CloudRunServicesResponse>(
-    `https://run.googleapis.com/v2/projects/${projectId}/locations/-/services${suffix ? `?${suffix}` : ""}`,
+    `https://run.googleapis.com/v2/projects/${projectId}/locations/${locationId}/services${suffix ? `?${suffix}` : ""}`,
     accessToken,
   );
 
@@ -92,6 +101,17 @@ export const listCloudRunServicesPage = async (
     }) ?? [];
 
   return { deployments: services, nextPageToken: body.nextPageToken };
+};
+
+export const listCloudRunLocations = async (projectId: string, accessToken: string): Promise<Location[]> => {
+  const body = await fetchGoogleApi<CloudRunLocationsResponse>(
+    `https://run.googleapis.com/v2/projects/${projectId}/locations`,
+    accessToken,
+  );
+
+  return (body.locations ?? [])
+    .map((location) => createLocation(location.locationId, location.displayName))
+    .sort((a, b) => a.id.localeCompare(b.id));
 };
 
 /**

--- a/src/cloud-run/api.ts
+++ b/src/cloud-run/api.ts
@@ -105,7 +105,7 @@ export const listCloudRunServicesPage = async (
 
 export const listCloudRunLocations = async (projectId: string, accessToken: string): Promise<Location[]> => {
   const body = await fetchGoogleApi<CloudRunLocationsResponse>(
-    `https://run.googleapis.com/v2/projects/${projectId}/locations`,
+    `https://run.googleapis.com/v1/projects/${projectId}/locations`,
     accessToken,
   );
 

--- a/src/cloud-run/useCloudRunServices.ts
+++ b/src/cloud-run/useCloudRunServices.ts
@@ -9,6 +9,25 @@ const CLOUD_RUN_SERVICE_LIMIT = 500;
 
 type PaginationTokens = Record<string, string>;
 
+const isNotFoundError = (error: unknown) => error instanceof Error && error.message.includes("Failed to fetch (404)");
+
+const listCloudRunServicesPageOrEmpty = async (
+  projectId: string,
+  locationId: string,
+  accessToken: string,
+  options: { pageSize: number; pageToken?: string },
+) => {
+  try {
+    return await listCloudRunServicesPage(projectId, locationId, accessToken, options);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return { deployments: [], nextPageToken: undefined };
+    }
+
+    throw error;
+  }
+};
+
 type SuccessResult = {
   services: CloudRunDeployment[];
   isLoading: boolean;
@@ -61,7 +80,7 @@ export const useCloudRunServices = (projectId: string): UseCloudRunServicesResul
       const pages = await Promise.all(
         regions.map(async (region) => ({
           region,
-          page: await listCloudRunServicesPage(projectId, region, accessToken, {
+          page: await listCloudRunServicesPageOrEmpty(projectId, region, accessToken, {
             pageSize: CLOUD_RUN_SERVICE_PAGE_SIZE,
             pageToken: paginationTokens[region],
           }),
@@ -103,7 +122,7 @@ export const useCloudRunServices = (projectId: string): UseCloudRunServicesResul
       const pages = await Promise.all(
         locations.map(async (location) => ({
           region: location.id,
-          page: await listCloudRunServicesPage(projId, location.id, token, {
+          page: await listCloudRunServicesPageOrEmpty(projId, location.id, token, {
             pageSize: CLOUD_RUN_SERVICE_PAGE_SIZE,
           }),
         })),

--- a/src/cloud-run/useCloudRunServices.ts
+++ b/src/cloud-run/useCloudRunServices.ts
@@ -1,11 +1,13 @@
 import { useCallback, useState } from "react";
 import { usePromise } from "@raycast/utils";
 import { useGoogleApi } from "../auth/google";
-import { listCloudRunServicesPage } from "./api";
+import { listCloudRunLocations, listCloudRunServicesPage } from "./api";
 import { CloudRunDeployment } from "./types";
 
 const CLOUD_RUN_SERVICE_PAGE_SIZE = 50;
 const CLOUD_RUN_SERVICE_LIMIT = 500;
+
+type PaginationTokens = Record<string, string>;
 
 type SuccessResult = {
   services: CloudRunDeployment[];
@@ -42,56 +44,83 @@ type UseCloudRunServicesResult = SuccessResult | LoadingResult | ErrorResult;
 export const useCloudRunServices = (projectId: string): UseCloudRunServicesResult => {
   const { accessToken } = useGoogleApi();
   const [services, setServices] = useState<CloudRunDeployment[]>([]);
-  const [nextPageToken, setNextPageToken] = useState<string | undefined>();
+  const [paginationTokens, setPaginationTokens] = useState<PaginationTokens>({});
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [isTruncated, setIsTruncated] = useState(false);
   const [loadMoreError, setLoadMoreError] = useState<Error | undefined>();
 
   const loadMore = useCallback(async () => {
-    if (!nextPageToken || isLoadingMore || isTruncated) {
+    const regions = Object.keys(paginationTokens);
+    if (regions.length === 0 || isLoadingMore || isTruncated) {
       return;
     }
 
     setIsLoadingMore(true);
     setLoadMoreError(undefined);
     try {
-      const page = await listCloudRunServicesPage(projectId, accessToken, {
-        pageSize: CLOUD_RUN_SERVICE_PAGE_SIZE,
-        pageToken: nextPageToken,
-      });
+      const pages = await Promise.all(
+        regions.map(async (region) => ({
+          region,
+          page: await listCloudRunServicesPage(projectId, region, accessToken, {
+            pageSize: CLOUD_RUN_SERVICE_PAGE_SIZE,
+            pageToken: paginationTokens[region],
+          }),
+        })),
+      );
 
-      const nextServices = [...services, ...page.deployments];
+      const nextServices = [...services, ...pages.flatMap(({ page }) => page.deployments)];
       if (nextServices.length >= CLOUD_RUN_SERVICE_LIMIT) {
         setServices(nextServices.slice(0, CLOUD_RUN_SERVICE_LIMIT));
-        setNextPageToken(undefined);
-        setIsTruncated(Boolean(page.nextPageToken) || nextServices.length > CLOUD_RUN_SERVICE_LIMIT);
+        setPaginationTokens({});
+        setIsTruncated(
+          pages.some(({ page }) => Boolean(page.nextPageToken)) || nextServices.length > CLOUD_RUN_SERVICE_LIMIT,
+        );
       } else {
         setServices(nextServices);
-        setNextPageToken(page.nextPageToken);
+        setPaginationTokens(
+          Object.fromEntries(
+            pages.flatMap(({ region, page }) => (page.nextPageToken ? [[region, page.nextPageToken]] : [])),
+          ),
+        );
       }
     } catch (error) {
       setLoadMoreError(error instanceof Error ? error : new Error(String(error)));
     } finally {
       setIsLoadingMore(false);
     }
-  }, [accessToken, services, isLoadingMore, isTruncated, nextPageToken, projectId]);
+  }, [accessToken, services, isLoadingMore, isTruncated, paginationTokens, projectId]);
 
   const noopLoadMore = useCallback(async () => undefined, []);
 
   const { isLoading, error } = usePromise(
     async (projId: string, token: string) => {
       setServices([]);
-      setNextPageToken(undefined);
+      setPaginationTokens({});
       setIsTruncated(false);
       setLoadMoreError(undefined);
 
-      const page = await listCloudRunServicesPage(projId, token, {
-        pageSize: CLOUD_RUN_SERVICE_PAGE_SIZE,
-      });
+      const locations = await listCloudRunLocations(projId, token);
+      const pages = await Promise.all(
+        locations.map(async (location) => ({
+          region: location.id,
+          page: await listCloudRunServicesPage(projId, location.id, token, {
+            pageSize: CLOUD_RUN_SERVICE_PAGE_SIZE,
+          }),
+        })),
+      );
 
-      setServices(page.deployments.slice(0, CLOUD_RUN_SERVICE_LIMIT));
-      setNextPageToken(page.deployments.length >= CLOUD_RUN_SERVICE_LIMIT ? undefined : page.nextPageToken);
-      setIsTruncated(page.deployments.length >= CLOUD_RUN_SERVICE_LIMIT && Boolean(page.nextPageToken));
+      const nextServices = pages.flatMap(({ page }) => page.deployments);
+      setServices(nextServices.slice(0, CLOUD_RUN_SERVICE_LIMIT));
+      setPaginationTokens(
+        nextServices.length >= CLOUD_RUN_SERVICE_LIMIT
+          ? {}
+          : Object.fromEntries(
+              pages.flatMap(({ region, page }) => (page.nextPageToken ? [[region, page.nextPageToken]] : [])),
+            ),
+      );
+      setIsTruncated(
+        nextServices.length >= CLOUD_RUN_SERVICE_LIMIT && pages.some(({ page }) => Boolean(page.nextPageToken)),
+      );
     },
     [projectId, accessToken],
   );
@@ -126,7 +155,7 @@ export const useCloudRunServices = (projectId: string): UseCloudRunServicesResul
     services,
     isLoading,
     isLoadingMore,
-    hasMore: Boolean(nextPageToken),
+    hasMore: Object.keys(paginationTokens).length > 0,
     isTruncated,
     loadMore,
     error: undefined,

--- a/src/cloud-scheduler/CloudSchedulerJobList.tsx
+++ b/src/cloud-scheduler/CloudSchedulerJobList.tsx
@@ -25,6 +25,17 @@ export const CloudSchedulerJobList = ({ projectId, locationId }: Props) => {
   return (
     <List
       isLoading={isLoading || isLoadingMore}
+      pagination={
+        canLoadMore
+          ? {
+              pageSize: 500,
+              hasMore: canLoadMore,
+              onLoadMore: () => {
+                void loadMore();
+              },
+            }
+          : undefined
+      }
       filtering
       onSearchTextChange={setSearchText}
       searchBarPlaceholder="Search loaded Cloud Scheduler jobs..."

--- a/src/cloud-scheduler/CloudSchedulerJobList.tsx
+++ b/src/cloud-scheduler/CloudSchedulerJobList.tsx
@@ -3,6 +3,7 @@ import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useCloudSchedulerJobs } from "./useCloudSchedulerJobs";
 import { toReadableCron } from "./cron";
 import { ErrorDetail } from "../components/ErrorDetail";
+import { useLoadMoreOnSearch } from "../hooks/useLoadMoreOnSearch";
 
 type Props = { projectId: string; locationId: string };
 
@@ -13,11 +14,13 @@ export const CloudSchedulerJobList = ({ projectId, locationId }: Props) => {
     locationId,
   );
 
+  const canLoadMore = hasMore && !isTruncated;
+  useLoadMoreOnSearch({ searchText, canLoadMore, isLoading, isLoadingMore, loadMore });
+
   if (error) {
     return <ErrorDetail error={error} />;
   }
 
-  const canLoadMore = hasMore && !isTruncated;
   const loadMoreAction = canLoadMore ? (
     <Action title="Load More Jobs" icon={Icon.ArrowDown} onAction={loadMore} />
   ) : undefined;

--- a/src/cloud-storage/CloudStorageBucketList.tsx
+++ b/src/cloud-storage/CloudStorageBucketList.tsx
@@ -23,6 +23,17 @@ export const CloudStorageBucketList = (props: Props) => {
   return (
     <List
       isLoading={isLoading || isLoadingMore}
+      pagination={
+        canLoadMore
+          ? {
+              pageSize: 50,
+              hasMore: canLoadMore,
+              onLoadMore: () => {
+                void loadMore();
+              },
+            }
+          : undefined
+      }
       filtering
       onSearchTextChange={setSearchText}
       searchBarPlaceholder="Search loaded buckets..."

--- a/src/cloud-storage/CloudStorageBucketList.tsx
+++ b/src/cloud-storage/CloudStorageBucketList.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useCloudStorage } from "./useCloudStorage";
 import { ErrorDetail } from "../components/ErrorDetail";
+import { useLoadMoreOnSearch } from "../hooks/useLoadMoreOnSearch";
 
 type Props = {
   projectId: string;
@@ -11,11 +12,13 @@ export const CloudStorageBucketList = (props: Props) => {
   const [searchText, setSearchText] = useState("");
   const { buckets, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } = useCloudStorage(props.projectId);
 
+  const canLoadMore = hasMore && !isTruncated;
+  useLoadMoreOnSearch({ searchText, canLoadMore, isLoading, isLoadingMore, loadMore });
+
   if (error) {
     return <ErrorDetail error={error} />;
   }
 
-  const canLoadMore = hasMore && !isTruncated;
   const loadMoreAction = canLoadMore ? (
     <Action title="Load More Buckets" icon={Icon.ArrowDown} onAction={loadMore} />
   ) : undefined;

--- a/src/hooks/useLoadMoreOnSearch.ts
+++ b/src/hooks/useLoadMoreOnSearch.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+
+type Options = {
+  searchText: string;
+  canLoadMore: boolean;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  loadMore: () => Promise<void>;
+};
+
+export const useLoadMoreOnSearch = ({ searchText, canLoadMore, isLoading, isLoadingMore, loadMore }: Options) => {
+  useEffect(() => {
+    if (!searchText.trim() || !canLoadMore || isLoading || isLoadingMore) {
+      return;
+    }
+
+    void loadMore();
+  }, [canLoadMore, isLoading, isLoadingMore, loadMore, searchText]);
+};

--- a/src/pubsub/PubSubSubscriptionList.tsx
+++ b/src/pubsub/PubSubSubscriptionList.tsx
@@ -1,21 +1,26 @@
+import { useState } from "react";
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { usePubSubResources } from "./usePubSubResources";
 import { ErrorDetail } from "../components/ErrorDetail";
+import { useLoadMoreOnSearch } from "../hooks/useLoadMoreOnSearch";
 
 type Props = {
   projectId: string;
 };
 
 export const PubSubSubscriptionList = (props: Props) => {
+  const [searchText, setSearchText] = useState("");
   const { resources, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } = usePubSubResources(
     props.projectId,
   );
+
+  const canLoadMore = hasMore && !isTruncated;
+  useLoadMoreOnSearch({ searchText, canLoadMore, isLoading, isLoadingMore, loadMore });
 
   if (error) {
     return <ErrorDetail error={error} />;
   }
 
-  const canLoadMore = hasMore && !isTruncated;
   const loadMoreAction = canLoadMore ? (
     <Action title="Load More Pub/Sub Resources" icon={Icon.ArrowDown} onAction={loadMore} />
   ) : undefined;
@@ -34,6 +39,8 @@ export const PubSubSubscriptionList = (props: Props) => {
             }
           : undefined
       }
+      filtering
+      onSearchTextChange={setSearchText}
       searchBarPlaceholder={
         canLoadMore
           ? "Search loaded topics/subscriptions. More resources are available via Load More."

--- a/src/pubsub/PubSubSubscriptionList.tsx
+++ b/src/pubsub/PubSubSubscriptionList.tsx
@@ -16,10 +16,24 @@ export const PubSubSubscriptionList = (props: Props) => {
   }
 
   const canLoadMore = hasMore && !isTruncated;
+  const loadMoreAction = canLoadMore ? (
+    <Action title="Load More Pub/Sub Resources" icon={Icon.ArrowDown} onAction={loadMore} />
+  ) : undefined;
 
   return (
     <List
       isLoading={isLoading || isLoadingMore}
+      pagination={
+        canLoadMore
+          ? {
+              pageSize: 50,
+              hasMore: canLoadMore,
+              onLoadMore: () => {
+                void loadMore();
+              },
+            }
+          : undefined
+      }
       searchBarPlaceholder={
         canLoadMore
           ? "Search loaded topics/subscriptions. More resources are available via Load More."
@@ -44,7 +58,7 @@ export const PubSubSubscriptionList = (props: Props) => {
           actions={
             <ActionPanel>
               <Action.OpenInBrowser url={resource.url} />
-              {canLoadMore && <Action title="Load More Pub/Sub Resources" icon={Icon.ArrowDown} onAction={loadMore} />}
+              {loadMoreAction}
             </ActionPanel>
           }
         />
@@ -54,11 +68,7 @@ export const PubSubSubscriptionList = (props: Props) => {
           key="load-more-pubsub"
           title="Load More Pub/Sub Resources"
           icon={Icon.ArrowDown}
-          actions={
-            <ActionPanel>
-              <Action title="Load More Pub/Sub Resources" icon={Icon.ArrowDown} onAction={loadMore} />
-            </ActionPanel>
-          }
+          actions={<ActionPanel>{loadMoreAction}</ActionPanel>}
         />
       )}
       {isTruncated && (

--- a/src/secret-manager/SecretManagerList.tsx
+++ b/src/secret-manager/SecretManagerList.tsx
@@ -25,6 +25,17 @@ export const SecretManagerList = (props: Props) => {
   return (
     <List
       isLoading={isLoading || isLoadingMore}
+      pagination={
+        canLoadMore
+          ? {
+              pageSize: 50,
+              hasMore: canLoadMore,
+              onLoadMore: () => {
+                void loadMore();
+              },
+            }
+          : undefined
+      }
       filtering
       onSearchTextChange={setSearchText}
       searchBarPlaceholder="Search loaded secrets..."

--- a/src/secret-manager/SecretManagerList.tsx
+++ b/src/secret-manager/SecretManagerList.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useSecretManager } from "./useSecretManager";
 import { ErrorDetail } from "../components/ErrorDetail";
+import { useLoadMoreOnSearch } from "../hooks/useLoadMoreOnSearch";
 
 type Props = {
   projectId: string;
@@ -13,11 +14,13 @@ export const SecretManagerList = (props: Props) => {
     props.projectId,
   );
 
+  const canLoadMore = hasMore && !isTruncated;
+  useLoadMoreOnSearch({ searchText, canLoadMore, isLoading, isLoadingMore, loadMore });
+
   if (error) {
     return <ErrorDetail error={error} />;
   }
 
-  const canLoadMore = hasMore && !isTruncated;
   const loadMoreAction = canLoadMore ? (
     <Action title="Load More Secrets" icon={Icon.ArrowDown} onAction={loadMore} />
   ) : undefined;


### PR DESCRIPTION
## Summary
- connect the Cloud Run list to Raycast's pagination API
- keep explicit Load More actions available while allowing scroll-based loading
- prevent load-more controls from appearing after the bounded list is truncated

## Verification
- npm run lint
- npm run type-check
- npm run build

closes #107