### PR TITLE
Fix load balancer detail URL

### DIFF
--- a/src/load-balancing/api.ts
+++ b/src/load-balancing/api.ts
@@ -66,7 +66,7 @@ const listForwardingRules = async (projectId: string, accessToken: string): Prom
             loadBalancingScheme: rule.loadBalancingScheme,
             url:
               region === "global"
-                ? `https://console.cloud.google.com/net-services/loadbalancing/details/global/${rule.name}?project=${projectId}`
+                ? `https://console.cloud.google.com/net-services/loadbalancing/details/httpAdvanced/${rule.name}?project=${projectId}`
                 : `https://console.cloud.google.com/net-services/loadbalancing/details/regional/${region}/${rule.name}?project=${projectId}`,
           });
         }


### PR DESCRIPTION
## Summary
- Update global load balancer detail links to use the valid `httpAdvanced` console route.

## Testing
- Not run (local shell/worktree commands are unavailable in this Codex session).

Closes #112