### PR TITLE
Clarify Cloud Run supported resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Cloud Logging shortcuts are rolled out incrementally. The table below shows the 
 |---|---|---|---|
 | Compute Engine | Compute | Instances | - |
 | Kubernetes Engine | Compute | - | - |
-| Cloud Run | Compute | Services | Yes |
+| Cloud Run | Compute | Services, Jobs & Worker Pools | Yes |
 | Cloud Functions | Compute | Functions (gen1) | Yes |
 | App Engine | Compute | Services | - |
 | Batch | Compute | - | - |


### PR DESCRIPTION
### Motivation
- Clarify that Cloud Run resource search covers Services, Jobs & Worker Pools and that Cloud Logging shortcuts apply to those Cloud Run deployment types (consistent with `src/cloud-run/types.ts` and `src/cloud-run/CloudRunServicesList.tsx`).

### Description
- Update `README.md` Supported Services table to change the Cloud Run `Resource Search` cell from `Services` to `Services, Jobs & Worker Pools` while leaving `Cloud Logging Shortcut` as `Yes`.

### Testing
- Ran `npm run lint` (reported Raycast package validation network/schema request failures and linting issues), `npm run type-check` (passed), and `npm run build` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a389c5f2c3c83248ef52cdbafc32dbf)