### PR TITLE
Add Console integrity audit skill

### DIFF
--- a/.agents/skills/check-console-integrity/SKILL.md
+++ b/.agents/skills/check-console-integrity/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: check-console-integrity
+description: Audit Google Cloud Console link integrity in this repository and produce an evidence-backed remediation plan. Use when asked to inspect, validate, investigate, or review URLs opened in Google Cloud Console; detect stale or invalid Console routes and retired services; compare link builders with API resources, Git history, issues, and tests; or repeat a Console integrity investigation without modifying application code.
+---
+
+# Check Console Integrity
+
+Audit Console links reproducibly. Keep the audit read-only unless the user separately asks to implement the remediation plan.
+
+## Workflow
+
+1. Read the applicable `AGENTS.md` files and inspect `git status`. Preserve unrelated and concurrent changes.
+2. Inventory every Console URL, including untracked source files:
+
+   ```sh
+   python3 .agents/skills/check-console-integrity/scripts/inventory_console_urls.py . --format json
+   ```
+
+   Use `--format tsv` for a compact, line-oriented view. Record production and test counts separately.
+3. Trace each production URL to its user-facing action and data source. Confirm which API field supplies every project, location, resource type, and resource identifier segment.
+4. Check local integrity:
+   - Parse fixed examples with a structured URL parser where practical.
+   - Verify path shape, query separators, parameter names, and percent-encoding.
+   - Distinguish display names, resource IDs, numeric IDs, emails, and fully qualified resource names.
+   - Check global, regional, generation, format, and resource-type variants independently.
+   - Compare related URL builders and expected URLs in tests for inconsistent conventions.
+5. Inspect `git blame`, focused file history, upstream diffs, and relevant repository issues or pull requests. Treat an historical fix as evidence, not proof that a current Console route remains valid.
+6. Validate current behavior against primary Google Cloud documentation. Follow project instructions about terminal-first research; use web search only when command-line sources are insufficient. Prefer current official Google sources and record the access date.
+7. Check service lifecycle separately from URL syntax. Identify shut-down services, end-of-sale restrictions, renamed products, and project- or organization-dependent availability.
+8. Assess regression coverage for every confirmed mismatch and every URL builder that has changed previously.
+9. Re-run the inventory before reporting if files changed concurrently during the audit.
+
+## Evidence Rules
+
+- Do not treat an HTTP success, login redirect, or generic Console shell as proof that a deep link opens the intended resource.
+- Do not mark a route invalid only because an unauthenticated request cannot reach its content.
+- Prefer, in order: current official product documentation, verified authenticated Console behavior supplied by the user, current repository behavior and tests, repository issue/history evidence, and third-party examples.
+- Label findings as `confirmed`, `probable`, `conditional`, or `unverified`. State what evidence would resolve anything below `confirmed`.
+- Separate route defects from unavailable or retired services. A syntactically valid link to a shut-down product is still an integrity finding.
+- If network access or authentication is unavailable, continue the local audit and report the external-validation gap explicitly.
+
+## Report Format
+
+Respond in the user's language and include:
+
+1. Scope and inventory counts.
+2. Findings ordered by impact, with confidence, clickable file/line references, expected behavior, and evidence.
+3. Conditional availability and lifecycle concerns.
+4. URL builders checked without a detected issue.
+5. Missing or weak regression tests.
+6. A prioritized, implementation-ready remediation and test plan.
+
+Do not edit application files, open issues, or post comments as part of the default audit.

--- a/.agents/skills/check-console-integrity/agents/openai.yaml
+++ b/.agents/skills/check-console-integrity/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: "Check Console Integrity"
+  display_name: "Google Cloud Console Integrity"
   short_description: "Audit Google Cloud Console links and service validity"
   default_prompt: "Use $check-console-integrity to audit Google Cloud Console links in this repository and produce an evidence-backed remediation plan."
 

--- a/.agents/skills/check-console-integrity/agents/openai.yaml
+++ b/.agents/skills/check-console-integrity/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Check Console Integrity"
+  short_description: "Audit Google Cloud Console links and service validity"
+  default_prompt: "Use $check-console-integrity to audit Google Cloud Console links in this repository and produce an evidence-backed remediation plan."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/check-console-integrity/scripts/inventory_console_urls.py
+++ b/.agents/skills/check-console-integrity/scripts/inventory_console_urls.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Inventory Google Cloud Console URLs in a repository."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Iterator, TypedDict
+
+
+CONSOLE_ORIGIN = "https://" + "console.cloud.google.com"
+URL_PATTERN = re.compile(re.escape(CONSOLE_ORIGIN) + r"[^\s`\"'<>]*")
+IGNORED_DIRECTORIES = {
+    ".cache",
+    ".codex",
+    ".git",
+    ".hg",
+    ".next",
+    ".svn",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "out",
+    "vendor",
+}
+TEST_DIRECTORY_NAMES = {"__tests__", "test", "tests"}
+TEST_FILE_PATTERN = re.compile(r"\.(?:spec|test)\.[^.]+$")
+
+
+class ConsoleUrl(TypedDict):
+    path: str
+    line: int
+    column: int
+    kind: str
+    context: str
+    url: str
+
+
+def is_test_path(path: Path) -> bool:
+    return any(part in TEST_DIRECTORY_NAMES for part in path.parts) or bool(TEST_FILE_PATTERN.search(path.name))
+
+
+def iter_text_files(root: Path) -> Iterator[Path]:
+    for current_root, directory_names, file_names in os.walk(root, followlinks=False):
+        directory_names[:] = sorted(name for name in directory_names if name not in IGNORED_DIRECTORIES)
+        current_path = Path(current_root)
+        for file_name in sorted(file_names):
+            path = current_path / file_name
+            if path.is_symlink() or not path.is_file():
+                continue
+            yield path
+
+
+def scan(root: Path) -> list[ConsoleUrl]:
+    resolved_root = root.resolve()
+    findings: list[ConsoleUrl] = []
+
+    for path in iter_text_files(resolved_root):
+        try:
+            contents = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        relative_path = path.relative_to(resolved_root)
+        context = "test" if is_test_path(relative_path) else "production"
+        for line_number, line in enumerate(contents.splitlines(), start=1):
+            for match in URL_PATTERN.finditer(line):
+                url = match.group(0)
+                findings.append(
+                    {
+                        "path": relative_path.as_posix(),
+                        "line": line_number,
+                        "column": match.start() + 1,
+                        "kind": "dynamic" if "${" in url else "fixed",
+                        "context": context,
+                        "url": url,
+                    }
+                )
+
+    return sorted(findings, key=lambda item: (item["path"], item["line"], item["column"], item["url"]))
+
+
+def write_json(findings: list[ConsoleUrl]) -> None:
+    json.dump(findings, sys.stdout, indent=2, ensure_ascii=False)
+    sys.stdout.write("\n")
+
+
+def write_tsv(findings: list[ConsoleUrl]) -> None:
+    fields = ("path", "line", "column", "kind", "context", "url")
+    sys.stdout.write("\t".join(fields) + "\n")
+    for finding in findings:
+        sys.stdout.write("\t".join(str(finding[field]) for field in fields) + "\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", default=".", type=Path, help="repository root (default: current directory)")
+    parser.add_argument("--format", choices=("json", "tsv"), default="json", help="output format (default: json)")
+    args = parser.parse_args()
+    if not args.root.is_dir():
+        parser.error(f"root is not a directory: {args.root}")
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    findings = scan(args.root)
+    if args.format == "json":
+        write_json(findings)
+    else:
+        write_tsv(findings)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/check-console-integrity/scripts/test_inventory_console_urls.py
+++ b/.agents/skills/check-console-integrity/scripts/test_inventory_console_urls.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import inventory_console_urls as inventory
+
+
+class InventoryConsoleUrlsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        origin = inventory.CONSOLE_ORIGIN
+
+        (self.root / "src").mkdir()
+        (self.root / "src" / "service.ts").write_text(
+            f'const fixed = "{origin}/compute/instances";\n'
+            f"const dynamic = `{origin}/run/detail/${{region}}/${{encodeURIComponent(name)}}?project=${{projectId}}`;\n",
+            encoding="utf-8",
+        )
+        (self.root / "src" / "service.test.ts").write_text(
+            f'const expected = "{origin}/compute/instances?project=sample";\n',
+            encoding="utf-8",
+        )
+
+        for ignored_directory in ("node_modules", "dist", ".codex"):
+            directory = self.root / ignored_directory
+            directory.mkdir()
+            (directory / "ignored.ts").write_text(f'const url = "{origin}/ignored";\n', encoding="utf-8")
+
+        (self.root / "binary.dat").write_bytes(b"\xff\xfe\x00")
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def test_scan_classifies_and_sorts_findings(self) -> None:
+        findings = inventory.scan(self.root)
+
+        self.assertEqual(
+            [(item["path"], item["line"], item["kind"], item["context"]) for item in findings],
+            [
+                ("src/service.test.ts", 1, "fixed", "test"),
+                ("src/service.ts", 1, "fixed", "production"),
+                ("src/service.ts", 2, "dynamic", "production"),
+            ],
+        )
+        self.assertEqual(findings[1]["column"], 16)
+        self.assertTrue(findings[2]["url"].endswith("${encodeURIComponent(name)}?project=${projectId}"))
+
+    def test_json_and_tsv_cli_output(self) -> None:
+        script = Path(inventory.__file__)
+        json_result = subprocess.run(
+            [sys.executable, str(script), str(self.root), "--format", "json"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        tsv_result = subprocess.run(
+            [sys.executable, str(script), str(self.root), "--format", "tsv"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(len(json.loads(json_result.stdout)), 3)
+        self.assertEqual(tsv_result.stdout.splitlines()[0], "path\tline\tcolumn\tkind\tcontext\turl")
+        self.assertEqual(len(tsv_result.stdout.splitlines()), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a repository-scoped Codex skill for auditing Google Cloud Console link integrity
- add a deterministic URL inventory script with JSON and TSV output
- classify fixed and dynamic links across production and test code
- add unit coverage and enable implicit skill invocation

## Motivation

Console routes and Google Cloud service availability change over time. This skill makes the audit repeatable, evidence-based, and read-only by default while producing an implementation-ready remediation plan.

## Developer impact

Codex automatically discovers the skill from `.agents/skills/check-console-integrity`. Related requests can invoke it implicitly, or users can invoke it explicitly with `$check-console-integrity`.

## Validation

- `python3 /home/yusuke/.codex-app/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/check-console-integrity`
- `python3 -m unittest discover -s .agents/skills/check-console-integrity/scripts -p 'test_*.py' -v`
- `npm run lint`
- `npm run type-check`
- `npm run build`