### PR TITLE
Allow cached projects without upfront auth

### DIFF
--- a/src/region/RegionList.tsx
+++ b/src/region/RegionList.tsx
@@ -1,6 +1,6 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
-import { useGoogleApi } from "../auth/google";
+import { useGoogleApi, withGoogleAccessToken } from "../auth/google";
 import { ErrorDetail } from "../components/ErrorDetail";
 import { Location } from "./types";
 
@@ -10,7 +10,7 @@ type Props = {
   target: (args: { projectId: string; locationId: string }) => React.ReactNode;
 };
 
-export const RegionList = (props: Props) => {
+const RegionListComponent = (props: Props) => {
   const { accessToken } = useGoogleApi();
   const {
     data: regions,
@@ -50,3 +50,5 @@ export const RegionList = (props: Props) => {
     </List>
   );
 };
+
+export const RegionList = withGoogleAccessToken(RegionListComponent);

--- a/src/region/withRegionSelect.tsx
+++ b/src/region/withRegionSelect.tsx
@@ -17,7 +17,9 @@ export const withRegionSelect = (props: Props) => {
         <RegionList
           projectId={props.projectId}
           fetchLocations={props.fetchLocations}
-          target={(args) => <props.target projectId={args.projectId} locationId={args.locationId} />}
+          target={(args: { projectId: string; locationId: string }) => (
+            <props.target projectId={args.projectId} locationId={args.locationId} />
+          )}
         />
       }
     />

--- a/src/resources/alloydb/AlloyDbClusterList.tsx
+++ b/src/resources/alloydb/AlloyDbClusterList.tsx
@@ -1,12 +1,13 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useAlloyDbClusters } from "./useAlloyDbClusters";
 import { ErrorDetail } from "../../components/ErrorDetail";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const AlloyDbClusterList = (props: Props) => {
+const AlloyDbClusterListComponent = (props: Props) => {
   const { clusters, isLoading, error } = useAlloyDbClusters(props.projectId);
 
   if (error) {
@@ -36,3 +37,5 @@ export const AlloyDbClusterList = (props: Props) => {
     </List>
   );
 };
+
+export const AlloyDbClusterList = withGoogleAccessToken(AlloyDbClusterListComponent);

--- a/src/resources/app-engine/AppEngineServiceList.tsx
+++ b/src/resources/app-engine/AppEngineServiceList.tsx
@@ -1,12 +1,13 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useAppEngineServices } from "./useAppEngineServices";
 import { ErrorDetail } from "../../components/ErrorDetail";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const AppEngineServiceList = (props: Props) => {
+const AppEngineServiceListComponent = (props: Props) => {
   const { services, isLoading, error } = useAppEngineServices(props.projectId);
 
   if (error) {
@@ -34,3 +35,5 @@ export const AppEngineServiceList = (props: Props) => {
     </List>
   );
 };
+
+export const AppEngineServiceList = withGoogleAccessToken(AppEngineServiceListComponent);

--- a/src/resources/artifact-registry/ArtifactRegistryRepositoryList.tsx
+++ b/src/resources/artifact-registry/ArtifactRegistryRepositoryList.tsx
@@ -1,13 +1,14 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { ErrorDetail } from "../../components/ErrorDetail";
 import { useArtifactRegistry } from "./useArtifactRegistry";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
   locationId: string;
 };
 
-export const ArtifactRegistryRepositoryList = ({ projectId, locationId }: Props) => {
+const ArtifactRegistryRepositoryListComponent = ({ projectId, locationId }: Props) => {
   const { repositories, isLoading, error } = useArtifactRegistry(projectId, locationId);
 
   if (error) {
@@ -34,3 +35,5 @@ export const ArtifactRegistryRepositoryList = ({ projectId, locationId }: Props)
     </List>
   );
 };
+
+export const ArtifactRegistryRepositoryList = withGoogleAccessToken(ArtifactRegistryRepositoryListComponent);

--- a/src/resources/cloud-build/CloudBuildList.tsx
+++ b/src/resources/cloud-build/CloudBuildList.tsx
@@ -2,6 +2,7 @@ import { Action, ActionPanel, Color, Icon, List } from "@raycast/api";
 import { useCloudBuilds } from "./useCloudBuilds";
 import { ErrorDetail } from "../../components/ErrorDetail";
 import { CloudBuildStatus } from "./types";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
@@ -29,7 +30,7 @@ const statusIcon = (status: CloudBuildStatus): { source: Icon; tintColor: Color 
   }
 };
 
-export const CloudBuildList = ({ projectId }: Props) => {
+const CloudBuildListComponent = ({ projectId }: Props) => {
   const { builds, isLoading, error } = useCloudBuilds(projectId);
 
   if (error) {
@@ -62,3 +63,5 @@ export const CloudBuildList = ({ projectId }: Props) => {
     </List>
   );
 };
+
+export const CloudBuildList = withGoogleAccessToken(CloudBuildListComponent);

--- a/src/resources/cloud-functions/CloudFunctionList.tsx
+++ b/src/resources/cloud-functions/CloudFunctionList.tsx
@@ -3,12 +3,13 @@ import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { OpenCloudLoggingAction } from "../../actions/cloud-logging/OpenCloudLoggingAction";
 import { ErrorDetail } from "../../components/ErrorDetail";
 import { useCloudFunctions } from "./useCloudFunctions";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const CloudFunctionList = ({ projectId }: Props) => {
+const CloudFunctionListComponent = ({ projectId }: Props) => {
   const [searchText, setSearchText] = useState("");
   const { functions, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } = useCloudFunctions(projectId);
 
@@ -81,3 +82,5 @@ export const CloudFunctionList = ({ projectId }: Props) => {
     </List>
   );
 };
+
+export const CloudFunctionList = withGoogleAccessToken(CloudFunctionListComponent);

--- a/src/resources/cloud-monitoring/AlertPolicyList.tsx
+++ b/src/resources/cloud-monitoring/AlertPolicyList.tsx
@@ -2,12 +2,13 @@ import { useState } from "react";
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { ErrorDetail } from "../../components/ErrorDetail";
 import { useAlertPolicies } from "./useAlertPolicies";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const AlertPolicyList = ({ projectId }: Props) => {
+const AlertPolicyListComponent = ({ projectId }: Props) => {
   const [searchText, setSearchText] = useState("");
   const { alertPolicies, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } =
     useAlertPolicies(projectId);
@@ -82,3 +83,5 @@ export const AlertPolicyList = ({ projectId }: Props) => {
     </List>
   );
 };
+
+export const AlertPolicyList = withGoogleAccessToken(AlertPolicyListComponent);

--- a/src/resources/cloud-run/CloudRunServicesList.tsx
+++ b/src/resources/cloud-run/CloudRunServicesList.tsx
@@ -4,12 +4,13 @@ import { OpenCloudLoggingAction } from "../../actions/cloud-logging/OpenCloudLog
 import { useCloudRunDeployments } from "./useCloudRunDeployments";
 import { ErrorDetail } from "../../components/ErrorDetail";
 import { useLoadMoreOnSearch } from "../../hooks/useLoadMoreOnSearch";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const CloudRunServicesList = (props: Props) => {
+const CloudRunServicesListComponent = (props: Props) => {
   const [searchText, setSearchText] = useState("");
   const { deployments, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } = useCloudRunDeployments(
     props.projectId,
@@ -110,3 +111,5 @@ export const CloudRunServicesList = (props: Props) => {
     </List>
   );
 };
+
+export const CloudRunServicesList = withGoogleAccessToken(CloudRunServicesListComponent);

--- a/src/resources/cloud-scheduler/CloudSchedulerJobList.tsx
+++ b/src/resources/cloud-scheduler/CloudSchedulerJobList.tsx
@@ -4,10 +4,11 @@ import { useCloudSchedulerJobs } from "./useCloudSchedulerJobs";
 import { toReadableCron } from "./cron";
 import { ErrorDetail } from "../../components/ErrorDetail";
 import { useLoadMoreOnSearch } from "../../hooks/useLoadMoreOnSearch";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = { projectId: string; locationId: string };
 
-export const CloudSchedulerJobList = ({ projectId, locationId }: Props) => {
+const CloudSchedulerJobListComponent = ({ projectId, locationId }: Props) => {
   const [searchText, setSearchText] = useState("");
   const { scheduledJobs, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } = useCloudSchedulerJobs(
     projectId,
@@ -91,3 +92,5 @@ export const CloudSchedulerJobList = ({ projectId, locationId }: Props) => {
     </List>
   );
 };
+
+export const CloudSchedulerJobList = withGoogleAccessToken(CloudSchedulerJobListComponent);

--- a/src/resources/cloud-sql/CloudSqlInstanceList.tsx
+++ b/src/resources/cloud-sql/CloudSqlInstanceList.tsx
@@ -2,12 +2,13 @@ import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useCloudSqlInstances } from "./useCloudSqlInstances";
 import { ErrorDetail } from "../../components/ErrorDetail";
 import { OpenCloudLoggingAction } from "../../actions/cloud-logging/OpenCloudLoggingAction";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const CloudSqlInstanceList = (props: Props) => {
+const CloudSqlInstanceListComponent = (props: Props) => {
   const { cloudSqlInstances, isLoading, error } = useCloudSqlInstances(props.projectId);
 
   if (error) {
@@ -34,3 +35,5 @@ export const CloudSqlInstanceList = (props: Props) => {
     </List>
   );
 };
+
+export const CloudSqlInstanceList = withGoogleAccessToken(CloudSqlInstanceListComponent);

--- a/src/resources/cloud-storage/CloudStorageBucketList.tsx
+++ b/src/resources/cloud-storage/CloudStorageBucketList.tsx
@@ -3,12 +3,13 @@ import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useCloudStorage } from "./useCloudStorage";
 import { ErrorDetail } from "../../components/ErrorDetail";
 import { useLoadMoreOnSearch } from "../../hooks/useLoadMoreOnSearch";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const CloudStorageBucketList = (props: Props) => {
+const CloudStorageBucketListComponent = (props: Props) => {
   const [searchText, setSearchText] = useState("");
   const { buckets, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } = useCloudStorage(props.projectId);
 
@@ -88,3 +89,5 @@ export const CloudStorageBucketList = (props: Props) => {
     </List>
   );
 };
+
+export const CloudStorageBucketList = withGoogleAccessToken(CloudStorageBucketListComponent);

--- a/src/resources/cloud-tasks/CloudTasksQueueList.tsx
+++ b/src/resources/cloud-tasks/CloudTasksQueueList.tsx
@@ -1,13 +1,14 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useCloudTasks } from "./useCloudTasks";
 import { ErrorDetail } from "../../components/ErrorDetail";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
   locationId: string;
 };
 
-export const CloudTasksQueueList = (props: Props) => {
+const CloudTasksQueueListComponent = (props: Props) => {
   const { queues, isLoading, error } = useCloudTasks(props.projectId, props.locationId);
 
   if (error) {
@@ -33,3 +34,5 @@ export const CloudTasksQueueList = (props: Props) => {
     </List>
   );
 };
+
+export const CloudTasksQueueList = withGoogleAccessToken(CloudTasksQueueListComponent);

--- a/src/resources/compute-engine/ComputeEngineInstanceList.tsx
+++ b/src/resources/compute-engine/ComputeEngineInstanceList.tsx
@@ -2,12 +2,13 @@ import { useState } from "react";
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useComputeEngineInstances } from "./useComputeEngineInstances";
 import { ErrorDetail } from "../../components/ErrorDetail";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const ComputeEngineInstanceList = (props: Props) => {
+const ComputeEngineInstanceListComponent = (props: Props) => {
   const [searchText, setSearchText] = useState("");
   const { instances, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } = useComputeEngineInstances(
     props.projectId,
@@ -91,3 +92,5 @@ export const ComputeEngineInstanceList = (props: Props) => {
     </List>
   );
 };
+
+export const ComputeEngineInstanceList = withGoogleAccessToken(ComputeEngineInstanceListComponent);

--- a/src/resources/error-reporting/ErrorReportingErrorList.tsx
+++ b/src/resources/error-reporting/ErrorReportingErrorList.tsx
@@ -3,12 +3,13 @@ import { useState } from "react";
 import { ErrorDetail } from "../../components/ErrorDetail";
 import { ErrorGroupDetail, getStatusColor } from "./ErrorReportingDetail";
 import { useErrorReporting } from "./useErrorReporting";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const ErrorReportingErrorList = ({ projectId }: Props) => {
+const ErrorReportingErrorListComponent = ({ projectId }: Props) => {
   const { errorGroups, isLoading, error } = useErrorReporting(projectId);
   const [showDetail, setShowDetail] = useState(false);
 
@@ -69,3 +70,5 @@ export const ErrorReportingErrorList = ({ projectId }: Props) => {
     </List>
   );
 };
+
+export const ErrorReportingErrorList = withGoogleAccessToken(ErrorReportingErrorListComponent);

--- a/src/resources/iam/IamList.tsx
+++ b/src/resources/iam/IamList.tsx
@@ -1,12 +1,13 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useIamPolicies } from "./useIamPolicies";
 import { ErrorDetail } from "../../components/ErrorDetail";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const IamList = (props: Props) => {
+const IamListComponent = (props: Props) => {
   const { iamMemberRoles, isLoading, error } = useIamPolicies(props.projectId);
 
   if (error) {
@@ -35,3 +36,5 @@ export const IamList = (props: Props) => {
     </List>
   );
 };
+
+export const IamList = withGoogleAccessToken(IamListComponent);

--- a/src/resources/kubernetes-engine/KubernetesEngineClusterList.tsx
+++ b/src/resources/kubernetes-engine/KubernetesEngineClusterList.tsx
@@ -2,12 +2,13 @@ import { useState } from "react";
 import { ActionPanel, Action, Icon, List } from "@raycast/api";
 import { useKubernetesEngineClusters } from "./useKubernetesEngineClusters";
 import { ErrorDetail } from "../../components/ErrorDetail";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const KubernetesEngineClusterList = ({ projectId }: Props) => {
+const KubernetesEngineClusterListComponent = ({ projectId }: Props) => {
   const [searchText, setSearchText] = useState("");
   const { clusters, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } =
     useKubernetesEngineClusters(projectId);
@@ -87,3 +88,5 @@ export const KubernetesEngineClusterList = ({ projectId }: Props) => {
     </List>
   );
 };
+
+export const KubernetesEngineClusterList = withGoogleAccessToken(KubernetesEngineClusterListComponent);

--- a/src/resources/load-balancing/LoadBalancerList.tsx
+++ b/src/resources/load-balancing/LoadBalancerList.tsx
@@ -1,12 +1,13 @@
 import { ActionPanel, Action, Icon, List } from "@raycast/api";
 import { useLoadBalancers } from "./useLoadBalancers";
 import { ErrorDetail } from "../../components/ErrorDetail";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const LoadBalancerList = ({ projectId }: Props) => {
+const LoadBalancerListComponent = ({ projectId }: Props) => {
   const { resources, isLoading, error } = useLoadBalancers(projectId);
 
   if (error) {
@@ -37,3 +38,5 @@ export const LoadBalancerList = ({ projectId }: Props) => {
     </List>
   );
 };
+
+export const LoadBalancerList = withGoogleAccessToken(LoadBalancerListComponent);

--- a/src/resources/project/useProjects.ts
+++ b/src/resources/project/useProjects.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { useGoogleApi } from "../../auth/google";
+import { google } from "../../auth/google";
 import { listProjects } from "./api";
 import { cacheProjects, listCachedProjects } from "./cache";
 import { Project } from "./types";
@@ -28,7 +28,6 @@ type ErrorResult = {
 type UseProjectsResult = LoadingResult | SuccessResult | ErrorResult;
 
 export const useProjects = (): UseProjectsResult => {
-  const { accessToken } = useGoogleApi();
   const [projects, setProjects] = useState<Project[] | undefined>();
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | undefined>();
@@ -38,6 +37,7 @@ export const useProjects = (): UseProjectsResult => {
     setError(undefined);
 
     try {
+      const accessToken = await google.authorize();
       const fetchedProjects = await listProjects(accessToken);
       await cacheProjects(fetchedProjects);
       setProjects(fetchedProjects);
@@ -47,7 +47,7 @@ export const useProjects = (): UseProjectsResult => {
     } finally {
       setIsLoading(false);
     }
-  }, [accessToken]);
+  }, []);
 
   useEffect(() => {
     (async () => {

--- a/src/resources/pubsub/PubSubSubscriptionList.tsx
+++ b/src/resources/pubsub/PubSubSubscriptionList.tsx
@@ -3,12 +3,13 @@ import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { usePubSubResources } from "./usePubSubResources";
 import { ErrorDetail } from "../../components/ErrorDetail";
 import { useLoadMoreOnSearch } from "../../hooks/useLoadMoreOnSearch";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const PubSubSubscriptionList = (props: Props) => {
+const PubSubSubscriptionListComponent = (props: Props) => {
   const [searchText, setSearchText] = useState("");
   const { resources, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } = usePubSubResources(
     props.projectId,
@@ -87,3 +88,5 @@ export const PubSubSubscriptionList = (props: Props) => {
     </List>
   );
 };
+
+export const PubSubSubscriptionList = withGoogleAccessToken(PubSubSubscriptionListComponent);

--- a/src/resources/secret-manager/SecretManagerList.tsx
+++ b/src/resources/secret-manager/SecretManagerList.tsx
@@ -3,12 +3,13 @@ import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useSecretManager } from "./useSecretManager";
 import { ErrorDetail } from "../../components/ErrorDetail";
 import { useLoadMoreOnSearch } from "../../hooks/useLoadMoreOnSearch";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const SecretManagerList = (props: Props) => {
+const SecretManagerListComponent = (props: Props) => {
   const [searchText, setSearchText] = useState("");
   const { secrets, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } = useSecretManager(
     props.projectId,
@@ -89,3 +90,5 @@ export const SecretManagerList = (props: Props) => {
     </List>
   );
 };
+
+export const SecretManagerList = withGoogleAccessToken(SecretManagerListComponent);

--- a/src/resources/service-account/ServiceAccountList.tsx
+++ b/src/resources/service-account/ServiceAccountList.tsx
@@ -1,12 +1,13 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useServiceAccounts } from "./useServiceAccounts";
 import { ErrorDetail } from "../../components/ErrorDetail";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const ServiceAccountList = (props: Props) => {
+const ServiceAccountListComponent = (props: Props) => {
   const { serviceAccounts, isLoading, error } = useServiceAccounts(props.projectId);
 
   if (error) {
@@ -33,3 +34,5 @@ export const ServiceAccountList = (props: Props) => {
     </List>
   );
 };
+
+export const ServiceAccountList = withGoogleAccessToken(ServiceAccountListComponent);

--- a/src/resources/vpc/VpcNetworkList.tsx
+++ b/src/resources/vpc/VpcNetworkList.tsx
@@ -1,12 +1,13 @@
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useVpcNetworks } from "./useVpcNetworks";
 import { ErrorDetail } from "../../components/ErrorDetail";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const VpcNetworkList = (props: Props) => {
+const VpcNetworkListComponent = (props: Props) => {
   const { networks, isLoading, error } = useVpcNetworks(props.projectId);
 
   if (error) {
@@ -33,3 +34,5 @@ export const VpcNetworkList = (props: Props) => {
     </List>
   );
 };
+
+export const VpcNetworkList = withGoogleAccessToken(VpcNetworkListComponent);

--- a/src/resources/workflows/WorkflowList.tsx
+++ b/src/resources/workflows/WorkflowList.tsx
@@ -2,12 +2,13 @@ import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useWorkflows } from "./useWorkflows";
 import { ErrorDetail } from "../../components/ErrorDetail";
 import { OpenCloudLoggingAction } from "../../actions/cloud-logging/OpenCloudLoggingAction";
+import { withGoogleAccessToken } from "../../auth/google";
 
 type Props = {
   projectId: string;
 };
 
-export const WorkflowList = ({ projectId }: Props) => {
+const WorkflowListComponent = ({ projectId }: Props) => {
   const { workflows, isLoading, error } = useWorkflows(projectId);
 
   if (error) {
@@ -34,3 +35,5 @@ export const WorkflowList = ({ projectId }: Props) => {
     </List>
   );
 };
+
+export const WorkflowList = withGoogleAccessToken(WorkflowListComponent);

--- a/src/search-google-cloud-resources.tsx
+++ b/src/search-google-cloud-resources.tsx
@@ -1,8 +1,7 @@
-import { withGoogleAccessToken } from "./auth/google";
 import { ProjectList } from "./resources/project/ProjectList";
 
 export const Command = () => {
   return <ProjectList />;
 };
 
-export default withGoogleAccessToken(Command);
+export default Command;

--- a/src/workload-identity/WorkloadIdentityPoolList.tsx
+++ b/src/workload-identity/WorkloadIdentityPoolList.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { ErrorDetail } from "../components/ErrorDetail";
 import { useWorkloadIdentityPools } from "./useWorkloadIdentityPools";
+import { withGoogleAccessToken } from "../auth/google";
 
 type Props = {
   projectId: string;
@@ -14,7 +15,7 @@ const formatEnum = (value: string) =>
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
 
-export const WorkloadIdentityPoolList = ({ projectId }: Props) => {
+const WorkloadIdentityPoolListComponent = ({ projectId }: Props) => {
   const [searchText, setSearchText] = useState("");
   const { pools, isLoading, isLoadingMore, hasMore, isTruncated, loadMore, error } =
     useWorkloadIdentityPools(projectId);
@@ -88,3 +89,5 @@ export const WorkloadIdentityPoolList = ({ projectId }: Props) => {
     </List>
   );
 };
+
+export const WorkloadIdentityPoolList = withGoogleAccessToken(WorkloadIdentityPoolListComponent);


### PR DESCRIPTION
## Summary
- Remove the command-level Google OAuth wrapper so cached projects can render before authentication.
- Load cached projects first and only start Google authorization when projects need to be refreshed or fetched with no cache.
- Move Google OAuth wrapping to each exported resource-list and region-list component so callers can import the authenticated export directly without individually wrapping every Action.Push target.
- Restore the import/type separator in the service resource module to avoid an unrelated formatting-only diff.

## Checks
- npm run lint
- npm run type-check
- npm run build

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4907d7fe4c832485c2ecae836871a2)