### PR TITLE
Add Compute Engine log search shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Cloud Logging shortcuts are available for selected resource types. The table bel
 
 | Service Name | Category | Resource Search | Cloud Logging Shortcut |
 |---|---|---|---|
-| Compute Engine | Compute | Instances | - |
+| Compute Engine | Compute | Instances | Yes |
 | Kubernetes Engine | Compute | Clusters | - |
 | Cloud Run | Compute | Services, Jobs & Worker Pools | Yes |
 | Cloud Functions | Compute | Functions (gen1) | Yes |

--- a/src/actions/cloud-logging/createCloudLoggingUrl.test.ts
+++ b/src/actions/cloud-logging/createCloudLoggingUrl.test.ts
@@ -17,6 +17,24 @@ const parseCloudLoggingUrl = (url: string): { query: string; projectId: string }
 };
 
 describe("createCloudLoggingUrl", () => {
+  it("creates a Compute Engine instance log query", () => {
+    const target: CloudLoggingTarget = {
+      kind: "gce-instance",
+      projectId: "sample-project",
+      instanceId: "1234567890123456789",
+      zone: "asia-northeast1-a",
+    };
+
+    expect(parseCloudLoggingUrl(createCloudLoggingUrl(target))).toEqual({
+      query: [
+        'resource.type="gce_instance"',
+        'resource.labels.instance_id="1234567890123456789"',
+        'resource.labels.zone="asia-northeast1-a"',
+      ].join("\n"),
+      projectId: "sample-project",
+    });
+  });
+
   it("creates a Cloud Functions gen1 log query", () => {
     const target: CloudLoggingTarget = {
       kind: "cloud-function-gen1",

--- a/src/actions/cloud-logging/createCloudLoggingUrl.ts
+++ b/src/actions/cloud-logging/createCloudLoggingUrl.ts
@@ -25,6 +25,12 @@ const createCloudLoggingQuery = (target: CloudLoggingTarget): string => {
         { key: "resource.labels.database_id", value: `${target.projectId}:${target.instanceId}` },
         { key: "resource.labels.region", value: target.region },
       ]);
+    case "gce-instance":
+      return createCloudLoggingQueryFromFilters([
+        { key: "resource.type", value: "gce_instance" },
+        { key: "resource.labels.instance_id", value: target.instanceId },
+        { key: "resource.labels.zone", value: target.zone },
+      ]);
     case "cloud-function-gen1":
       return createCloudLoggingQueryFromFilters([
         { key: "resource.type", value: "cloud_function" },

--- a/src/actions/cloud-logging/types.ts
+++ b/src/actions/cloud-logging/types.ts
@@ -12,6 +12,12 @@ export type CloudLoggingTarget =
       region: string;
     }
   | {
+      kind: "gce-instance";
+      projectId: string;
+      instanceId: string;
+      zone: string;
+    }
+  | {
       kind: "cloud-function-gen1";
       projectId: string;
       name: string;

--- a/src/resources/compute-engine/ComputeEngineInstanceList.tsx
+++ b/src/resources/compute-engine/ComputeEngineInstanceList.tsx
@@ -3,6 +3,7 @@ import { Action, ActionPanel, Icon, List } from "@raycast/api";
 import { useComputeEngineInstances } from "./useComputeEngineInstances";
 import { ErrorDetail } from "../../components/ErrorDetail";
 import { withGoogleAccessToken } from "../../auth/google";
+import { OpenCloudLoggingAction } from "../../actions/cloud-logging/OpenCloudLoggingAction";
 
 type Props = {
   projectId: string;
@@ -59,6 +60,7 @@ const ComputeEngineInstanceListComponent = (props: Props) => {
             actions={
               <ActionPanel>
                 <Action.OpenInBrowser url={instance.url} />
+                <OpenCloudLoggingAction target={instance} />
                 <Action.CopyToClipboard title="Copy Instance ID" content={instance.id} />
                 {instance.internalIp && (
                   <Action.CopyToClipboard title="Copy Internal IP" content={instance.internalIp} />

--- a/src/resources/compute-engine/api.ts
+++ b/src/resources/compute-engine/api.ts
@@ -63,6 +63,9 @@ export const listComputeEngineInstancesPage = async (
 
         return {
           id: instance.id,
+          kind: "gce-instance" as const,
+          projectId,
+          instanceId: instance.id,
           name: instance.name,
           status: instance.status,
           zone,

--- a/src/resources/compute-engine/types.ts
+++ b/src/resources/compute-engine/types.ts
@@ -1,3 +1,5 @@
+import { CloudLoggingTarget } from "../../actions/cloud-logging/types";
+
 export type ComputeEngineInstance = {
   id: string;
   name: string;
@@ -7,4 +9,4 @@ export type ComputeEngineInstance = {
   internalIp?: string;
   externalIp?: string;
   url: string;
-};
+} & Extract<CloudLoggingTarget, { kind: "gce-instance" }>;


### PR DESCRIPTION
## Summary

- add Compute Engine instances as Cloud Logging targets
- open Logs Explorer from each instance with filters for resource type, instance ID, and zone
- document Compute Engine Cloud Logging shortcut support

## Why

Compute Engine instances could be opened from resource search, but their logs could not be accessed directly. This adds the same Cloud Logging shortcut available for other supported resources while using stable monitored-resource labels to select the instance.

## User impact

Users can select **Open Logs** on a Compute Engine instance to open Logs Explorer with the relevant instance logs already filtered.

## Validation

- `npm test -- --run src/actions/cloud-logging/createCloudLoggingUrl.test.ts`
- `npm run lint`
- `npm run type-check`
- `npm run build`