### PR TITLE
Fill in initial release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 # Google Cloud Shortcut Changelog
 
 ## [Initial Version] - {PR_MERGE_DATE}
+
+- Initial release of Google Cloud Shortcut, with Google sign-in, project selection and cache refresh, search and direct Google Cloud Console navigation for supported services and resources, and Cloud Logging shortcuts for supported resource types.


### PR DESCRIPTION
## Summary

- add a substantive initial release note for Google Cloud Shortcut
- preserve `{PR_MERGE_DATE}` for Raycast to replace when the Store pull request is merged

## Why

The changelog previously contained only its initial-version heading, so it did not describe the functionality included in the first Store release.

## Impact

The initial Store version history now summarizes Google sign-in, project selection and refresh, supported service and resource navigation, and Cloud Logging shortcuts. This documentation-only change does not affect runtime behavior.

## Validation

- `npm run lint`
- `npm run type-check`
- `npm run build`
- `git diff --check`

Closes #73
